### PR TITLE
add prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ RustPBX is a high-performance, secure software-defined PBX (Private Branch Excha
 - Rust 1.75 or later
 - Cargo package manager
 - opus, alsa
+- pkg-config
 
 Linux: 
 ```bash


### PR DESCRIPTION
since [opus-rs](https://github.com/SpaceManiac/opus-rs) have requirements from [audiopus_sys](https://crates.io/crates/audiopus_sys), it need to know the locations of preinstalled opus headers/libraries。

> By default, audiopus_sys will use pkg-config on Unix or GNU. Setting the environment variable LIBOPUS_NO_PKG or OPUS_NO_PKG will bypass probing for Opus via pkg-config.

or you need to set environment variable LIBOPUS_LIB_DIR or OPUS_LIB_DIR.