### PR TITLE
field name didn't match with frontend request

### DIFF
--- a/static/js/agent.js
+++ b/static/js/agent.js
@@ -801,11 +801,11 @@ function mainApp() {
                     if (this.config.asr.appId) asrConfig.appId = this.config.asr.appId;
                     if (this.config.asr.secretId) asrConfig.secretId = this.config.asr.secretId;
                     if (this.config.asr.secretKey) asrConfig.secretKey = this.config.asr.secretKey;
-                    if (this.config.asr.model) asrConfig.model = this.config.asr.model;
+                    if (this.config.asr.model) asrConfig.modelType = this.config.asr.model;
                     if (this.config.asr.language) asrConfig.language = this.config.asr.language;
                 } else if (this.config.asr.provider === 'voiceapi') {
                     if (this.config.asr.endpoint) asrConfig.endpoint = this.config.asr.endpoint;
-                    if (this.config.asr.model) asrConfig.model = this.config.asr.model;
+                    if (this.config.asr.model) asrConfig.modelType = this.config.asr.model;
                     if (this.config.asr.language) asrConfig.language = this.config.asr.language;
                 }
 


### PR DESCRIPTION
The front end use field name `model`, but back end use `model_type`. https://github.com/restsend/rustpbx/blob/f2623f67b35e5ef9c8367b0245d0841b40a15168/static/js/agent.js#L804

They are not matching, so back end will use default model `16_zh_en` and ignore the model parameter in request.
