### PR TITLE
Refactor: Remove redundant trait bounds and lifetimes

### DIFF
--- a/src/media/tests/tts_track.rs
+++ b/src/media/tests/tts_track.rs
@@ -27,7 +27,7 @@ impl SynthesisClient for MockSynthesisClient {
         &'a self,
         _text: &'a str,
         _option: Option<SynthesisOption>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>> {
         // Generate 1 second of sine wave at 440Hz, 16kHz sample rate, but split into chunks
         let sample_rate = 16000;
         let frequency = 440.0; // A4 note

--- a/src/synthesis/aliyun.rs
+++ b/src/synthesis/aliyun.rs
@@ -199,7 +199,7 @@ impl SynthesisClient for AliyunTtsClient {
         &'a self,
         text: &'a str,
         option: Option<SynthesisOption>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>> {
         let option = self.option.merge_with(option);
         let api_key = self.get_api_key(&option)?;
         let task_id = Uuid::new_v4().to_string();

--- a/src/synthesis/mod.rs
+++ b/src/synthesis/mod.rs
@@ -109,14 +109,14 @@ impl SynthesisOption {
 }
 
 #[async_trait]
-pub trait SynthesisClient: Send + Sync {
+pub trait SynthesisClient: Send {
     fn provider(&self) -> SynthesisType;
     /// Synthesize text to audio and return a stream of audio chunks
     async fn synthesize<'a>(
         &'a self,
         text: &'a str,
         option: Option<SynthesisOption>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send + 'a>>>;
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>>;
 }
 
 impl Default for SynthesisOption {

--- a/src/synthesis/tencent_cloud.rs
+++ b/src/synthesis/tencent_cloud.rs
@@ -280,7 +280,7 @@ impl SynthesisClient for TencentCloudTtsClient {
         &'a self,
         text: &'a str,
         option: Option<SynthesisOption>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>> {
         // Use the new WebSocket streaming implementation
         self.synthesize_text_stream(text, option).await
     }

--- a/src/synthesis/voiceapi.rs
+++ b/src/synthesis/voiceapi.rs
@@ -48,7 +48,7 @@ impl VoiceApiTtsClient {
         &'a self,
         text: &'a str,
         option: Option<SynthesisOption>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>> {
         let option = self.option.merge_with(option);
         let endpoint = option
             .endpoint
@@ -161,7 +161,7 @@ impl SynthesisClient for VoiceApiTtsClient {
         &'a self,
         text: &'a str,
         option: Option<SynthesisOption>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>> {
         self.ws_synthesize(text, option).await
     }
 }


### PR DESCRIPTION
## Summary
Clean up redundant trait bounds and lifetimes throughout the codebase.

## What Changed
- Removed unnecessary `Send` trait bound and lifetime parameter `'a`

## Why
- SynthesisClient is not a mutable object shared between threads
- `text: &'a str` is used as part of request parameter or json payload, so it is not captured by request `Future`


