### PR TITLE
fix: dump event file

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -60,6 +60,20 @@ pub struct AppStateBuilder {
 impl AppStateInner {
     pub fn get_dump_events_file(&self, session_id: &String) -> String {
         let root = Path::new(&self.config.recorder_path);
+        if !root.exists() {
+            match std::fs::create_dir_all(root) {
+                Ok(_) => {
+                    info!("created dump events root: {}", root.to_string_lossy());
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to create dump events root: {} {}",
+                        e,
+                        root.to_string_lossy()
+                    );
+                }
+            }
+        }
         root.join(format!("{}.events.jsonl", session_id))
             .to_string_lossy()
             .to_string()


### PR DESCRIPTION
if parent dir not exists https://github.com/restsend/rustpbx/blob/42dcb6597429186b0eb8bb987d13ae1f9c032276/src/call/active_call.rs#L871
will not work