### PR TITLE
improve(record): create path if not exists and change type of ptime

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -392,8 +392,8 @@ impl ActiveCall {
             } else {
                 recorder_option.samplerate
             };
-            let recorder_ptime = if recorder_option.ptime.is_zero() {
-                Duration::from_millis(200)
+            let recorder_ptime = if recorder_option.ptime == 0 {
+                200
             } else {
                 recorder_option.ptime
             };

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -255,7 +255,7 @@ impl MediaStream {
             info!(
                 session_id = session_id_clone,
                 sample_rate = recorder_option.samplerate,
-                ptime = recorder_option.ptime.as_millis(),
+                ptime = recorder_option.ptime,
                 "start recorder",
             );
 


### PR DESCRIPTION
* Create parent path if not exits
* Change ptime field of RecordOption from `Duration` to `u32` for easy to Serialization in other language