### PR TITLE
fix: add x-cloak directive to hide DTMF before Alpine.js initialization

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,9 @@
             color: rgba(148, 163, 184, 0.7);
             opacity: 1;
         }
+        [x-cloak] { 
+            display: none !important; 
+        }
     </style>
 </head>
 
@@ -514,7 +517,7 @@
     </div>
 
     <!-- DTMF Keypad Modal -->
-    <div x-show="showDtmfKeypad" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+    <div x-cloak x-show="showDtmfKeypad" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
         x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-200"
         x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0">


### PR DESCRIPTION
When we first load the page, the DTMF view flashes briefly because the Alpine data hasn't been initialized yet. 
Refer to here:  [https://alpinejs.dev/directives/cloak](https://alpinejs.dev/directives/cloak)