### PR TITLE
Fix(queue): queue that set accept immediately hangup bug

### DIFF
--- a/src/proxy/proxy_call/session.rs
+++ b/src/proxy/proxy_call/session.rs
@@ -559,18 +559,21 @@ impl CallSession {
             self.answer = Some(answer);
         }
 
-        let headers = if self.answer.is_some() {
-            Some(vec![rsip::Header::ContentType("application/sdp".into())])
-        } else {
-            None
-        };
+        if !self.server_dialog.state().is_confirmed() {
+            let headers = if self.answer.is_some() {
+                Some(vec![rsip::Header::ContentType("application/sdp".into())])
+            } else {
+                None
+            };
 
-        if let Err(e) = self
-            .server_dialog
-            .accept(headers, self.answer.clone().map(|sdp| sdp.into_bytes()))
-        {
-            return Err(anyhow!("Failed to send 200 OK: {}", e));
+            if let Err(e) = self
+                .server_dialog
+                .accept(headers, self.answer.clone().map(|sdp| sdp.into_bytes()))
+            {
+                return Err(anyhow!("Failed to send 200 OK: {}", e));
+            }
         }
+        
         self.mark_active_call_answered();
         if first_answer {
             let callee = self


### PR DESCRIPTION
If queue set accept immediately: the dialog will be accept twice:
1. https://github.com/restsend/rustpbx/blob/229dadba2fb3dc1cac088f7be41b4b1811627d23/src/proxy/proxy_call/queue.rs#L76
2. https://github.com/restsend/rustpbx/blob/229dadba2fb3dc1cac088f7be41b4b1811627d23/src/proxy/proxy_call.rs#L1869
And the state of dialog will change back to waitAck: https://github.com/restsend/rsipstack/blob/62c4b197c3c5e53aa835070124a0d7e0bf9eeee4/src/dialog/server_dialog.rs#L208
That lead `bye` and `handle` methods of `serverInviteDialog` working incorrect, which dependent on the `Confirmed` state.