### PR TITLE
fix(console): Diagnostics side bar have different class with other items

### DIFF
--- a/templates/console/layout.html
+++ b/templates/console/layout.html
@@ -219,8 +219,8 @@
                     <a href="{{ bp }}/diagnostics"
                         class="group mt-1 flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-slate-50 transition-all duration-200 {{ 'bg-sky-50 text-sky-700' if nav_active=='diagnostics' else 'text-slate-700' }}"
                         :class="{ 'justify-center gap-0 px-2 py-3': sidebarCollapsed }" title="Diagnostics">
-                        <svg class="h-5 w-5 flex-shrink-0 {{ 'text-sky-600' if nav_active=='diagnostics' else 'text-slate-400 group-hover:text-slate-600' }}"
-                            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                            stroke="currentColor" class="size-6">
                             <path stroke-linecap="round" stroke-linejoin="round"
                                 d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
                         </svg>


### PR DESCRIPTION
<img width="278" height="465" alt="截屏2025-11-27 11 58 25" src="https://github.com/user-attachments/assets/36e27cad-8280-4ca3-8ac2-ff864f12172c" />

Diagnostics have lighter color and does not align with other items