### PR TITLE
fix(proxy): fix call loop when callee does not exists

### DIFF
--- a/src/proxy/proxy_call.rs
+++ b/src/proxy/proxy_call.rs
@@ -1379,7 +1379,11 @@ impl ProxyCall {
                         ));
                     }
                     Ok(None) => {
-                        info!(session_id = ?dialplan.session_id, callee = %callee_uri, "user not found in auth backend, continue");
+                        info!(session_id = ?dialplan.session_id, callee = %callee_uri, "user not found in auth backend, reject");
+                        return Err((
+                            rsip::StatusCode::NotFound,
+                            Some("User not found".to_string()),
+                        ));
                     }
                     Err(e) => {
                         warn!(session_id = ?dialplan.session_id, callee = %callee_uri, "failed to lookup user in auth backend: {}", e);


### PR DESCRIPTION
fix #77 
When auth module is disabled, call a user not exists will lead to self call loop