### PR TITLE
fixed parsing of target trunks during `RouteRule` parsing from database model

### DIFF
--- a/src/proxy/data.rs
+++ b/src/proxy/data.rs
@@ -906,11 +906,19 @@ fn convert_route(
             rules
         });
 
+    #[derive(Deserialize)]
+    struct RouteTrunkDocument {
+        name: String,
+    }
+
     let target_trunks: Vec<String> = model
         .target_trunks
         .clone()
-        .and_then(|value| serde_json::from_value::<Vec<String>>(value).ok())
-        .unwrap_or_default();
+        .and_then(|value| serde_json::from_value::<Vec<RouteTrunkDocument>>(value).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|trunk| trunk.name)
+        .collect::<Vec<_>>();
 
     let dest = if target_trunks.is_empty() {
         None


### PR DESCRIPTION
This PR addresses #79

During conversion from the database model into `RouteRule`, it was erroneously assumed that `target_trunks` is stored as `Vec<String>`, when in fact it's stored as `Vec<RouteTrunkDocument>`.