### PR TITLE
fix(console): missing unclosed '

### DIFF
--- a/templates/console/routing_form.html
+++ b/templates/console/routing_form.html
@@ -198,7 +198,7 @@
                                 <label class="text-xs font-semibold uppercase tracking-wide text-slate-500"
                                     x-text="field.label"></label>
                                 <div class="relative">
-                                    <input type="text" :name="'match[' + field.key + ']"
+                                    <input type="text" :name="'match[' + field.key + ']'"
                                         x-model="route.match[field.key]"
                                         class="w-full rounded-lg border border-slate-200 pl-3 pr-16 py-2 text-sm text-slate-800 focus:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-200"
                                         :placeholder="field.placeholder">


### PR DESCRIPTION
```html
<input type="text" :name="'match[' + field.key + ']"
                                 missing ' at here ^
```