### PR TITLE
fix(call): use the first result to predicate if support webrtc or not

### DIFF
--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -403,7 +403,10 @@ impl CallModule {
 
         if callee_is_same_realm {
             if let Ok(results) = self.inner.server.locator.lookup(&callee_uri).await {
-                loc.supports_webrtc |= results.iter().any(|item| item.supports_webrtc);
+                loc.supports_webrtc |= results
+                    .first()
+                    .map(|item| item.supports_webrtc)
+                    .unwrap_or_default();
             }
         }
 


### PR DESCRIPTION
If i have registered through webrtc, and then use sip phone, it will be rejected.