### PR TITLE
Add missing [proxy] section declaration to Readme.md default config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ log_level = "debug"
 media_cache_path = "/tmp/mediacache"
 database_url = "sqlite://rustpbx.sqlite3"
 
+[proxy]
 modules = ["acl", "auth", "registrar", "call"]
 addr = "0.0.0.0"
 udp_port = 15060


### PR DESCRIPTION
fix for this crash:
└─$ cargo run --bin rustpbx -- --conf config.pbx.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.31s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v6.1.2 note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/rustpbx --conf config.pbx.toml`

thread 'main' panicked at src/bin/rustpbx.rs:88:28: Failed to load config: TOML parse error at line 38, column 3
   |
38 | [[proxy.user_backends]]
   |   ^^^^^
missing field `addr`

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace