### PR TITLE
fix: recorder does not work when transcoding happends and sipflow is enabled.

### DIFF
--- a/src/media/transcoder.rs
+++ b/src/media/transcoder.rs
@@ -64,7 +64,7 @@ impl Transcoder {
             sequence_number: Some(output_sequence),
             payload_type: Some(self.target.payload_type()),
             marker: frame.marker,
-            raw_packet: None,
+            raw_packet: frame.raw_packet.clone(),
             source_addr: frame.source_addr,
         }
     }


### PR DESCRIPTION
Fix: keep the `raw_packet` when transcoding