### PR TITLE
fix: fix sipflow rtp recording

### DIFF
--- a/src/media/recorder.rs
+++ b/src/media/recorder.rs
@@ -92,6 +92,7 @@ impl Recorder {
         let src_codec = codec;
         let codec = match codec {
             CodecType::Opus => CodecType::PCMU,
+            CodecType::G722 => CodecType::PCMU,
             _ => codec,
         };
 

--- a/src/media/transcoder.rs
+++ b/src/media/transcoder.rs
@@ -64,7 +64,7 @@ impl Transcoder {
             sequence_number: Some(output_sequence),
             payload_type: Some(self.target.payload_type()),
             marker: frame.marker,
-            raw_packet: frame.raw_packet.clone(),
+            raw_packet: None,
             source_addr: frame.source_addr,
         }
     }


### PR DESCRIPTION
This pull request contains following fix:

* Standard G722 does not support stereo, g722 recording does not work.
  *  decode g722 to pcmu
* Remove the raw_packet.clone(), get the packet before transcoding.
* Since sipflow rtp decode need the header, use `packet.mashal()` instead of `packet.payload`, and use`RtpPacket::parse` instead of manually parse which assume fixed size header.
* Using zstd magic number predicate instead of compare the size. (the compressed data may have same size with the original)
