### PR TITLE
removing missing test mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ rustpbx.toml
 model.md
 *.raw
 *.db
-archive/
+/storage/

--- a/src/addons/archive/mod.rs
+++ b/src/addons/archive/mod.rs
@@ -15,9 +15,6 @@ use tracing::{error, info};
 
 mod handlers;
 
-#[cfg(test)]
-mod tests;
-
 #[derive(Debug, Clone)]
 pub struct ManualTaskStatus {
     pub status: String, // "running", "success", "error"


### PR DESCRIPTION
* Missing tests mod in archive addon
* `archive/` will ignore `src/addons/archive`