### PR TITLE
fix: remove missing tests mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ rustpbx.toml
 model.md
 *.raw
 *.db
-archive/
+/archive/

--- a/src/addons/archive/mod.rs
+++ b/src/addons/archive/mod.rs
@@ -15,9 +15,6 @@ use tracing::{error, info};
 
 mod handlers;
 
-#[cfg(test)]
-mod tests;
-
 #[derive(Debug, Clone)]
 pub struct ManualTaskStatus {
     pub status: String, // "running", "success", "error"


### PR DESCRIPTION
* Removing missing tests mod in archive addon
* `archive/` in .gitignore was falsely configured, and it will ignore the change `src/addons/archive/mod.rs`