### PR TITLE
Fix inbound trunk calls rejected as external realm

### DIFF
--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -389,6 +389,12 @@ impl CallModule {
             (true, true) => DialDirection::Outbound,
             (true, false) => DialDirection::Outbound,
             (false, true) => DialDirection::Inbound,
+            (false, false) if is_from_trunk => {
+                // Trunk providers (e.g. Telnyx) may use internal IPs in To header.
+                // Since the call arrived from a recognized trunk, treat as inbound.
+                debug!(dialog_id, caller_realm = ?caller.realm, callee_realm, "Trunk call with external callee realm, treating as inbound");
+                DialDirection::Inbound
+            }
             (false, false) => {
                 warn!(dialog_id, caller_realm = ?caller.realm, callee_realm, "Both caller and callee are external realm, reject");
                 return Err((


### PR DESCRIPTION
Fixes inbound trunk call direction detection when both caller and callee hosts appear external.

Changes included:
- In `src/proxy/call.rs`, treat `(caller_is_local=false, callee_is_local=false)` as inbound when `is_from_trunk` is true
- Avoid rejecting valid trunk-originated INVITEs with 403 in this scenario

Ref: #129
