### PR TITLE
fix: decode sipflow opus payload type 96

### DIFF
--- a/src/sipflow/wav_utils.rs
+++ b/src/sipflow/wav_utils.rs
@@ -107,7 +107,7 @@ pub fn generate_wav_from_packets_ex(
             8 => CodecType::PCMA,
             9 => CodecType::G722,
             18 => CodecType::G729,
-            97 | 111 => CodecType::Opus,
+            96 | 111 => CodecType::Opus,
             _ => CodecType::PCMU,
         };
         legs_codecs.entry(*leg).or_default().push(codec);
@@ -173,7 +173,7 @@ pub fn generate_wav_from_packets_ex(
             8 => CodecType::PCMA,
             9 => CodecType::G722,
             18 => CodecType::G729,
-            97 | 111 => CodecType::Opus,
+            96 | 111 => CodecType::Opus,
             _ => CodecType::PCMU,
         };
 


### PR DESCRIPTION
treat SipFlow Opus payload type 96 as Opus instead of 97
