### PR TITLE
fix: external ip does not take effect for http router

### DIFF
--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -286,7 +286,8 @@ impl SipSession {
             .get_or_create_server_invite(tx, state_tx, None, local_contact.clone())
             .map_err(|e| anyhow!("Failed to create server dialog: {}", e))?;
 
-        let use_media_proxy = Self::check_media_proxy(&context, &server.proxy_config.media_proxy);
+        let use_media_proxy =
+            Self::check_media_proxy(&context, &context.dialplan.media.proxy_mode);
 
         let caller_media_builder = crate::media::MediaStreamBuilder::new()
             .with_id(format!("{}-caller", session_id))
@@ -536,7 +537,11 @@ impl SipSession {
     }
 
     async fn handle_dialog_state(&mut self, state: DialogState) -> Result<()> {
-        debug!("Handling caller dialog state");
+        debug!(
+            session_id = %self.context.session_id,
+            state = %state,
+            "Caller dialog state"
+        );
         match state {
             DialogState::Confirmed(_, _) => {
                 self.update_leg_state(&LegId::from("caller"), LegState::Connected);
@@ -587,7 +592,11 @@ impl SipSession {
     }
 
     async fn handle_callee_state(&mut self, state: DialogState) -> Result<()> {
-        debug!("Handling callee state");
+        debug!(
+            session_id = %self.context.session_id,
+            state = %state,
+            "Callee dialog state"
+        );
         match state {
             DialogState::Confirmed(_, _) => {
                 self.update_leg_state(&LegId::from("callee"), LegState::Connected);
@@ -1726,9 +1735,24 @@ impl SipSession {
                 "Media proxy enabled for same-type transport (anchored media)"
             );
 
+            let media_config = &self.context.dialplan.media;
             let mut track_builder = RtpTrackBuilder::new(track_id.clone())
                 .with_cancel_token(self.callee_peer.cancel_token())
-                .with_enable_latching(self.server.proxy_config.enable_latching);
+                .with_enable_latching(media_config.enable_latching);
+
+            if let Some(ref external_ip) = media_config.external_ip {
+                track_builder = track_builder.with_external_ip(external_ip.clone());
+            }
+
+            let (start_port, end_port) = if callee_is_webrtc {
+                (media_config.webrtc_port_start, media_config.webrtc_port_end)
+            } else {
+                (media_config.rtp_start_port, media_config.rtp_end_port)
+            };
+
+            if let (Some(start), Some(end)) = (start_port, end_port) {
+                track_builder = track_builder.with_rtp_range(start, end);
+            }
 
             if let Some(ref caller_offer) = self.caller_offer {
                 let codecs =
@@ -1740,6 +1764,9 @@ impl SipSession {
 
             if callee_is_webrtc {
                 track_builder = track_builder.with_mode(rustrtc::TransportMode::WebRtc);
+                if let Some(ref ice_servers) = media_config.ice_servers {
+                    track_builder = track_builder.with_ice_servers(ice_servers.clone());
+                }
             }
 
             let track = track_builder.build();

--- a/src/proxy/routing/http.rs
+++ b/src/proxy/routing/http.rs
@@ -17,11 +17,12 @@ use tracing::{info, warn};
 pub struct HttpCallRouter {
     pub config: HttpRouterConfig,
     pub rtp_config: RtpConfig,
+    pub default_media_proxy_mode: MediaProxyMode,
     pub client: reqwest::Client,
 }
 
 impl HttpCallRouter {
-    pub fn new(config: HttpRouterConfig, rtp_config: RtpConfig) -> Self {
+    pub fn new(config: HttpRouterConfig, rtp_config: RtpConfig, default_media_proxy_mode: MediaProxyMode) -> Self {
         let mut builder = reqwest::Client::builder();
         if let Some(timeout) = config.timeout_ms {
             builder = builder.timeout(Duration::from_millis(timeout));
@@ -31,6 +32,7 @@ impl HttpCallRouter {
         Self {
             config,
             rtp_config,
+            default_media_proxy_mode,
             client: builder.build().unwrap_or_default(),
         }
     }
@@ -272,7 +274,8 @@ impl CallRouter for HttpCallRouter {
 
                 let mut dialplan = Dialplan::new(call_id, original.clone(), direction);
 
-                // Apply server RTP config so SDP uses the correct public IP, port range, etc.
+                // Start from server defaults, then let HTTP router override individual fields.
+                dialplan.media.proxy_mode = self.default_media_proxy_mode;
                 dialplan.media.external_ip = self.rtp_config.external_ip.clone();
                 dialplan.media.rtp_start_port = self.rtp_config.start_port;
                 dialplan.media.rtp_end_port = self.rtp_config.end_port;

--- a/src/proxy/routing/http_tests.rs
+++ b/src/proxy/routing/http_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::call::{SipUser, TransactionCookie};
-    use crate::config::{HttpRouterConfig, RtpConfig};
+    use crate::config::{HttpRouterConfig, MediaProxyMode, RtpConfig};
     use crate::proxy::call::CallRouter;
     use crate::proxy::routing::http::HttpCallRouter;
     use axum::{Json, Router, routing::post};
@@ -43,7 +43,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
 
-        let router = HttpCallRouter::new(config, RtpConfig::default());
+        let router = HttpCallRouter::new(config, RtpConfig::default(), MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,
@@ -140,7 +140,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
 
-        let router = HttpCallRouter::new(config, RtpConfig::default());
+        let router = HttpCallRouter::new(config, RtpConfig::default(), MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,
@@ -240,7 +240,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
 
-        let router = HttpCallRouter::new(config, RtpConfig::default());
+        let router = HttpCallRouter::new(config, RtpConfig::default(), MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,
@@ -339,7 +339,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
 
-        let router = HttpCallRouter::new(config, RtpConfig::default());
+        let router = HttpCallRouter::new(config, RtpConfig::default(), MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,
@@ -425,7 +425,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
 
-        let router = HttpCallRouter::new(config, RtpConfig::default());
+        let router = HttpCallRouter::new(config, RtpConfig::default(), MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,
@@ -516,7 +516,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
 
-        let router = HttpCallRouter::new(config, RtpConfig::default());
+        let router = HttpCallRouter::new(config, RtpConfig::default(), MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,
@@ -609,7 +609,7 @@ mod tests {
             ..Default::default()
         };
 
-        let router = HttpCallRouter::new(config, rtp_config);
+        let router = HttpCallRouter::new(config, rtp_config, MediaProxyMode::None);
 
         let request = rsipstack::sip::Request {
             method: rsipstack::sip::Method::Invite,

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -532,6 +532,7 @@ impl SipServerBuilder {
                 call_router = Some(Box::new(crate::proxy::routing::http::HttpCallRouter::new(
                     http_router_config.clone(),
                     rtp_config.clone(),
+                    self.config.media_proxy
                 )));
             }
         }
@@ -702,7 +703,7 @@ impl SipServer {
         crate::utils::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            
+
             loop {
                 tokio::select! {
                     _ = cleanup_cancel.cancelled() => break,


### PR DESCRIPTION
This PR backports the external-IP/candidate-address fix for HTTP-routed calls onto upstream `main`.

Changes included:
- use the effective per-call `dialplan.media.proxy_mode` in unified `SipSession`
- seed the HTTP-router dialplan media mode from server config before applying HTTP overrides
- regenerate anchored same-transport callee SDP with `external_ip`, port range, and ICE settings from the dialplan media config

This branch intentionally does not include the separate Contact/default-contact PR.