### PR TITLE
improve: session timer use update as default and callee hangup

### DIFF
--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -460,20 +460,21 @@ impl CallModule {
             }
         };
 
-        let mut loc = Location {
+        let loc = Location {
             aor: callee_uri.clone(),
             ..Default::default()
         };
+        let mut locs = vec![loc];
         let mut internal_lookup_empty = false;
 
         if callee_is_same_realm {
             if let Ok(results) = self.inner.server.locator.lookup(&callee_uri).await {
                 internal_lookup_empty = results.is_empty();
-                loc.supports_webrtc |= results.iter().any(|item| item.supports_webrtc);
+                if !results.is_empty() {
+                    locs = results;
+                }
             }
         }
-
-        let locs = vec![loc];
         let caller_uri = match caller.from.as_ref() {
             Some(uri) => uri.clone(),
             None => original
@@ -482,7 +483,6 @@ impl CallModule {
                 .uri()
                 .map_err(|e| RouteError::from((anyhow::anyhow!(e), None)))?,
         };
-
         let preview_option = InviteOption {
             callee: callee_uri.clone(),
             caller: caller_uri.clone(),

--- a/src/proxy/proxy_call/session_timer.rs
+++ b/src/proxy/proxy_call/session_timer.rs
@@ -13,6 +13,7 @@ pub const HEADER_SESSION_EXPIRES: &str = "Session-Expires";
 pub const HEADER_MIN_SE: &str = "Min-SE";
 pub const HEADER_SUPPORTED: &str = "Supported";
 pub const HEADER_REQUIRE: &str = "Require";
+pub const HEADER_ALLOW: &str = "Allow";
 pub const TIMER_TAG: &str = "timer";
 
 /// Default session expiration interval (30 minutes per RFC 4028 recommendation)
@@ -353,6 +354,19 @@ pub fn has_timer_support(headers: &rsipstack::sip::Headers) -> bool {
         rsipstack::sip::Header::Other(n, v) if n.eq_ignore_ascii_case(HEADER_SUPPORTED) => {
             v.split(',').any(|v| v.trim() == TIMER_TAG)
         }
+        _ => false,
+    })
+}
+
+pub fn allows_update(headers: &rsipstack::sip::Headers) -> bool {
+    headers.iter().any(|h| match h {
+        rsipstack::sip::Header::Allow(v) => v
+            .to_string()
+            .split(',')
+            .any(|m| m.trim().eq_ignore_ascii_case("UPDATE")),
+        rsipstack::sip::Header::Other(n, v) if n.eq_ignore_ascii_case(HEADER_ALLOW) => v
+            .split(',')
+            .any(|m| m.trim().eq_ignore_ascii_case("UPDATE")),
         _ => false,
     })
 }

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -36,9 +36,9 @@ use crate::proxy::proxy_call::{
     reporter::CallReporter,
     session_timer::{
         DEFAULT_SESSION_EXPIRES, HEADER_MIN_SE, HEADER_SESSION_EXPIRES, HEADER_SUPPORTED,
-        MIN_MIN_SE, SessionRefresher, SessionTimerState, build_default_session_timer_headers,
-        build_session_timer_headers, get_header_value, has_timer_support, parse_min_se,
-        parse_session_expires,
+        MIN_MIN_SE, SessionRefresher, SessionTimerState, allows_update,
+        build_default_session_timer_headers, build_session_timer_headers, get_header_value,
+        has_timer_support, parse_min_se, parse_session_expires,
     },
     state::{CallContext, CallSessionRecordSnapshot, SessionHangupMessage},
 };
@@ -113,6 +113,7 @@ pub struct SipSession {
     pub routed_destination: Option<String>,
 
     timers: HashMap<DialogId, SessionTimerState>,
+    refresh_update_supported: HashMap<DialogId, bool>,
     timer_queue: DelayQueue<DialogId>,
     timer_keys: HashMap<DialogId, delay_queue::Key>,
 
@@ -246,6 +247,7 @@ impl SipSession {
             routed_contact: None,
             routed_destination: None,
             timers: HashMap::new(),
+            refresh_update_supported: HashMap::new(),
             timer_queue: DelayQueue::new(),
             timer_keys: HashMap::new(),
             callee_event_tx: None,
@@ -586,7 +588,18 @@ impl SipSession {
                     rsipstack::sip::StatusCode::SessionIntervalTooSmall
                 };
 
-                let _ = tx_handle.reply(status).await;
+                let headers = if update_result.is_err() {
+                    self.timers.get(&dialog_id).map(|timer| {
+                        vec![rsipstack::sip::Header::Other(
+                            HEADER_MIN_SE.to_string(),
+                            timer.min_se.as_secs().to_string(),
+                        )]
+                    })
+                } else {
+                    None
+                };
+
+                let _ = tx_handle.respond(status, headers, None).await;
             }
             DialogState::Terminated(_, reason) => {
                 self.update_leg_state(&LegId::from("caller"), LegState::Ended);
@@ -634,8 +647,18 @@ impl SipSession {
                 if let Err(e) = self.update_dialog_timer_from_headers(&dialog_id, &request.headers)
                 {
                     warn!(%dialog_id, error = %e, "Failed to refresh callee session timer");
+                    let headers = self.timers.get(&dialog_id).map(|timer| {
+                        vec![rsipstack::sip::Header::Other(
+                            HEADER_MIN_SE.to_string(),
+                            timer.min_se.as_secs().to_string(),
+                        )]
+                    });
                     let _ = tx_handle
-                        .reply(rsipstack::sip::StatusCode::SessionIntervalTooSmall)
+                        .respond(
+                            rsipstack::sip::StatusCode::SessionIntervalTooSmall,
+                            headers,
+                            None,
+                        )
                         .await;
                     return Ok(());
                 }
@@ -647,6 +670,7 @@ impl SipSession {
                 self.callee_dialogs.remove(&terminated_dialog_id);
                 self.unschedule_timer(&terminated_dialog_id);
                 self.timers.remove(&terminated_dialog_id);
+                self.refresh_update_supported.remove(&terminated_dialog_id);
                 self.callee_guards
                     .retain(|guard| guard.id() != &terminated_dialog_id);
 
@@ -2389,6 +2413,7 @@ impl SipSession {
 
         self.callee_dialogs.clear();
         self.timers.clear();
+        self.refresh_update_supported.clear();
         self.timer_queue.clear();
         self.timer_keys.clear();
 
@@ -2413,6 +2438,7 @@ impl SipSession {
         let dialog_id = self.caller_dialog_id();
 
         let supported = has_timer_support(headers);
+        let update_supported = allows_update(headers);
         let session_expires_value = get_header_value(headers, HEADER_SESSION_EXPIRES);
         let mut timer = SessionTimerState::default();
 
@@ -2443,6 +2469,8 @@ impl SipSession {
         }
 
         self.timers.insert(dialog_id.clone(), timer);
+        self.refresh_update_supported
+            .insert(dialog_id.clone(), update_supported);
         self.schedule_timer(dialog_id);
 
         Ok(())
@@ -2455,6 +2483,7 @@ impl SipSession {
         default_expires: u64,
     ) {
         let headers = &response.headers;
+        let update_supported = allows_update(headers);
         let session_expires_value = get_header_value(headers, HEADER_SESSION_EXPIRES);
 
         let mut timer = SessionTimerState::default();
@@ -2471,6 +2500,8 @@ impl SipSession {
         timer.refresher = refresher;
 
         self.timers.insert(dialog_id.clone(), timer);
+        self.refresh_update_supported
+            .insert(dialog_id.clone(), update_supported);
         self.schedule_timer(dialog_id);
     }
 
@@ -2522,36 +2553,249 @@ impl SipSession {
         }
     }
 
+    fn prefers_update_refresh(&self, dialog_id: &DialogId) -> bool {
+        self.refresh_update_supported
+            .get(dialog_id)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    fn apply_refresh_min_se(
+        &mut self,
+        dialog_id: &DialogId,
+        headers: &rsipstack::sip::Headers,
+    ) -> Result<bool> {
+        let Some(min_se_value) = get_header_value(headers, HEADER_MIN_SE) else {
+            return Ok(false);
+        };
+        let Some(min_se) = parse_min_se(&min_se_value) else {
+            return Ok(false);
+        };
+
+        let timer = self
+            .timers
+            .get_mut(dialog_id)
+            .ok_or_else(|| anyhow!("No session timer for dialog {}", dialog_id))?;
+        if timer.min_se < min_se {
+            timer.min_se = min_se;
+        }
+        if timer.session_interval < min_se {
+            timer.session_interval = min_se;
+        }
+
+        Ok(true)
+    }
+
+    fn complete_refresh_from_response(
+        &mut self,
+        dialog_id: &DialogId,
+        response: &rsipstack::sip::Response,
+    ) -> Result<()> {
+        if let Some(timer) = self.timers.get_mut(dialog_id) {
+            if let Err(e) = Self::apply_timer_headers(timer, &response.headers) {
+                timer.fail_refresh();
+                return Err(e);
+            }
+            timer.complete_refresh();
+        }
+        Ok(())
+    }
+
+    async fn try_server_update_refresh(&mut self, dialog_id: &DialogId) -> Result<bool> {
+        let headers = {
+            let timer = self
+                .timers
+                .get(dialog_id)
+                .ok_or_else(|| anyhow!("No caller timer for dialog {}", dialog_id))?;
+            build_session_timer_headers(timer, false)
+        };
+
+        let response = match self.server_dialog.update(Some(headers), None).await {
+            Ok(response) => response,
+            Err(_) => return Ok(false),
+        };
+
+        match response {
+            Some(resp)
+                if resp.status_code.kind()
+                    == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+            {
+                self.complete_refresh_from_response(dialog_id, &resp)?;
+                Ok(true)
+            }
+            Some(resp)
+                if resp.status_code == StatusCode::SessionIntervalTooSmall
+                    && self.apply_refresh_min_se(dialog_id, &resp.headers)? =>
+            {
+                let retry_headers = {
+                    let timer = self
+                        .timers
+                        .get(dialog_id)
+                        .ok_or_else(|| anyhow!("No caller timer for dialog {}", dialog_id))?;
+                    build_session_timer_headers(timer, false)
+                };
+
+                match self.server_dialog.update(Some(retry_headers), None).await {
+                    Ok(Some(retry_resp))
+                        if retry_resp.status_code.kind()
+                            == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+                    {
+                        self.complete_refresh_from_response(dialog_id, &retry_resp)?;
+                        Ok(true)
+                    }
+                    _ => Ok(false),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    async fn try_callee_update_refresh(&mut self, dialog_id: &DialogId) -> Result<bool> {
+        let headers = {
+            let timer = self
+                .timers
+                .get(dialog_id)
+                .ok_or_else(|| anyhow!("No callee timer for dialog {}", dialog_id))?;
+            build_session_timer_headers(timer, false)
+        };
+
+        let Some(mut dialog) = self.server.dialog_layer.get_dialog(dialog_id) else {
+            return Err(anyhow!("No callee dialog found for {}", dialog_id));
+        };
+
+        let response = match &mut dialog {
+            Dialog::ClientInvite(invite_dialog) => match invite_dialog.update(Some(headers), None).await
+            {
+                Ok(response) => response,
+                Err(_) => return Ok(false),
+            },
+            _ => return Err(anyhow!("Dialog {} is not a client INVITE dialog", dialog_id)),
+        };
+
+        match response {
+            Some(resp)
+                if resp.status_code.kind()
+                    == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+            {
+                self.complete_refresh_from_response(dialog_id, &resp)?;
+                Ok(true)
+            }
+            Some(resp)
+                if resp.status_code == StatusCode::SessionIntervalTooSmall
+                    && self.apply_refresh_min_se(dialog_id, &resp.headers)? =>
+            {
+                let retry_headers = {
+                    let timer = self
+                        .timers
+                        .get(dialog_id)
+                        .ok_or_else(|| anyhow!("No callee timer for dialog {}", dialog_id))?;
+                    build_session_timer_headers(timer, false)
+                };
+
+                let Some(mut dialog) = self.server.dialog_layer.get_dialog(dialog_id) else {
+                    return Err(anyhow!("No callee dialog found for {}", dialog_id));
+                };
+
+                match &mut dialog {
+                    Dialog::ClientInvite(invite_dialog) => {
+                        match invite_dialog.update(Some(retry_headers), None).await {
+                            Ok(Some(retry_resp))
+                                if retry_resp.status_code.kind()
+                                    == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+                            {
+                                self.complete_refresh_from_response(dialog_id, &retry_resp)?;
+                                Ok(true)
+                            }
+                            _ => Ok(false),
+                        }
+                    }
+                    _ => Err(anyhow!("Dialog {} is not a client INVITE dialog", dialog_id)),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
     async fn send_server_session_refresh(&mut self) -> Result<()> {
-        info!("Sending session refresh (re-INVITE)");
         let dialog_id = self.caller_dialog_id();
 
+        if self.prefers_update_refresh(&dialog_id) && self.try_server_update_refresh(&dialog_id).await?
+        {
+            return Ok(());
+        }
+
+        let body = self.answer.clone().map(|sdp| sdp.into_bytes());
         let headers = {
             let timer = self
                 .timers
                 .get(&dialog_id)
                 .ok_or_else(|| anyhow!("No caller timer for dialog {}", dialog_id))?;
-            build_session_timer_headers(timer, true)
+            build_session_timer_headers(timer, body.is_some())
         };
 
-        let body = self.answer.clone().map(|sdp| sdp.into_bytes());
-
         match self.server_dialog.reinvite(Some(headers), body).await {
-            Ok(response) => {
-                info!("Session refresh (re-INVITE) successful");
-                if let Some(timer) = self.timers.get_mut(&dialog_id) {
-                    if let Some(resp) = response.as_ref() {
-                        if let Err(e) = Self::apply_timer_headers(timer, &resp.headers) {
-                            timer.fail_refresh();
-                            return Err(e);
-                        }
+            Ok(Some(resp))
+                if resp.status_code.kind()
+                    == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+            {
+                self.complete_refresh_from_response(&dialog_id, &resp)
+            }
+            Ok(Some(resp))
+                if resp.status_code == StatusCode::SessionIntervalTooSmall
+                    && self.apply_refresh_min_se(&dialog_id, &resp.headers)? =>
+            {
+                let retry_body = self.answer.clone().map(|sdp| sdp.into_bytes());
+                let retry_headers = {
+                    let timer = self
+                        .timers
+                        .get(&dialog_id)
+                        .ok_or_else(|| anyhow!("No caller timer for dialog {}", dialog_id))?;
+                    build_session_timer_headers(timer, retry_body.is_some())
+                };
+
+                match self.server_dialog.reinvite(Some(retry_headers), retry_body).await {
+                    Ok(Some(retry_resp))
+                        if retry_resp.status_code.kind()
+                            == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+                    {
+                        self.complete_refresh_from_response(&dialog_id, &retry_resp)
                     }
-                    timer.complete_refresh();
+                    Ok(Some(retry_resp)) => {
+                        if let Some(timer) = self.timers.get_mut(&dialog_id) {
+                            timer.fail_refresh();
+                        }
+                        Err(anyhow!(
+                            "re-INVITE rejected with status {}",
+                            retry_resp.status_code
+                        ))
+                    }
+                    Ok(None) => {
+                        if let Some(timer) = self.timers.get_mut(&dialog_id) {
+                            timer.fail_refresh();
+                        }
+                        Err(anyhow!("re-INVITE timed out"))
+                    }
+                    Err(e) => {
+                        if let Some(timer) = self.timers.get_mut(&dialog_id) {
+                            timer.fail_refresh();
+                        }
+                        Err(anyhow!("re-INVITE failed: {}", e))
+                    }
                 }
-                Ok(())
+            }
+            Ok(Some(resp)) => {
+                if let Some(timer) = self.timers.get_mut(&dialog_id) {
+                    timer.fail_refresh();
+                }
+                Err(anyhow!("re-INVITE rejected with status {}", resp.status_code))
+            }
+            Ok(None) => {
+                if let Some(timer) = self.timers.get_mut(&dialog_id) {
+                    timer.fail_refresh();
+                }
+                Err(anyhow!("re-INVITE timed out"))
             }
             Err(e) => {
-                warn!(error = %e, "Session refresh (re-INVITE) failed");
                 if let Some(timer) = self.timers.get_mut(&dialog_id) {
                     timer.fail_refresh();
                 }
@@ -2561,10 +2805,16 @@ impl SipSession {
     }
 
     async fn send_callee_session_refresh(&mut self, dialog_id: &DialogId) -> Result<()> {
+        if self.prefers_update_refresh(dialog_id) && self.try_callee_update_refresh(dialog_id).await?
+        {
+            return Ok(());
+        }
+
+        let body = self.callee_offer.clone().map(|sdp| sdp.into_bytes());
         let headers = self
             .timers
             .get(dialog_id)
-            .map(|timer| build_session_timer_headers(timer, false))
+            .map(|timer| build_session_timer_headers(timer, body.is_some()))
             .ok_or_else(|| anyhow!("No callee timer for dialog {}", dialog_id))?;
 
         let Some(mut dialog) = self.server.dialog_layer.get_dialog(dialog_id) else {
@@ -2576,43 +2826,94 @@ impl SipSession {
 
         let response = match &mut dialog {
             Dialog::ClientInvite(invite_dialog) => invite_dialog
-                .update(Some(headers), None)
+                .reinvite(Some(headers), body)
                 .await
-                .map_err(|e| anyhow!("UPDATE failed: {}", e)),
-            _ => Err(anyhow!(
-                "Dialog {} is not a client INVITE dialog",
-                dialog_id
-            )),
+                .map_err(|e| anyhow!("re-INVITE failed: {}", e)),
+            _ => Err(anyhow!("Dialog {} is not a client INVITE dialog", dialog_id)),
         };
 
-        let result = match response {
+        match response {
             Ok(Some(resp))
                 if resp.status_code.kind()
                     == rsipstack::sip::status_code::StatusCodeKind::Successful =>
             {
-                Ok(resp)
+                self.complete_refresh_from_response(dialog_id, &resp)
             }
-            Ok(Some(resp)) => Err(anyhow!("UPDATE rejected with status {}", resp.status_code)),
-            Ok(None) => Err(anyhow!("UPDATE timed out")),
-            Err(e) => Err(e),
-        };
+            Ok(Some(resp))
+                if resp.status_code == StatusCode::SessionIntervalTooSmall
+                    && self.apply_refresh_min_se(dialog_id, &resp.headers)? =>
+            {
+                let retry_body = self.callee_offer.clone().map(|sdp| sdp.into_bytes());
+                let retry_headers = self
+                    .timers
+                    .get(dialog_id)
+                    .map(|timer| build_session_timer_headers(timer, retry_body.is_some()))
+                    .ok_or_else(|| anyhow!("No callee timer for dialog {}", dialog_id))?;
 
-        if let Some(timer) = self.timers.get_mut(dialog_id) {
-            match &result {
-                Ok(resp) => {
-                    if let Err(e) = Self::apply_timer_headers(timer, &resp.headers) {
+                let Some(mut retry_dialog) = self.server.dialog_layer.get_dialog(dialog_id) else {
+                    if let Some(timer) = self.timers.get_mut(dialog_id) {
                         timer.fail_refresh();
-                        return Err(e);
                     }
-                    timer.complete_refresh();
+                    return Err(anyhow!("No callee dialog found for {}", dialog_id));
+                };
+
+                let retry_response = match &mut retry_dialog {
+                    Dialog::ClientInvite(invite_dialog) => invite_dialog
+                        .reinvite(Some(retry_headers), retry_body)
+                        .await
+                        .map_err(|e| anyhow!("re-INVITE failed: {}", e)),
+                    _ => Err(anyhow!("Dialog {} is not a client INVITE dialog", dialog_id)),
+                };
+
+                match retry_response {
+                    Ok(Some(retry_resp))
+                        if retry_resp.status_code.kind()
+                            == rsipstack::sip::status_code::StatusCodeKind::Successful =>
+                    {
+                        self.complete_refresh_from_response(dialog_id, &retry_resp)
+                    }
+                    Ok(Some(retry_resp)) => {
+                        if let Some(timer) = self.timers.get_mut(dialog_id) {
+                            timer.fail_refresh();
+                        }
+                        Err(anyhow!(
+                            "re-INVITE rejected with status {}",
+                            retry_resp.status_code
+                        ))
+                    }
+                    Ok(None) => {
+                        if let Some(timer) = self.timers.get_mut(dialog_id) {
+                            timer.fail_refresh();
+                        }
+                        Err(anyhow!("re-INVITE timed out"))
+                    }
+                    Err(e) => {
+                        if let Some(timer) = self.timers.get_mut(dialog_id) {
+                            timer.fail_refresh();
+                        }
+                        Err(e)
+                    }
                 }
-                Err(_) => {
+            }
+            Ok(Some(resp)) => {
+                if let Some(timer) = self.timers.get_mut(dialog_id) {
                     timer.fail_refresh();
                 }
+                Err(anyhow!("re-INVITE rejected with status {}", resp.status_code))
+            }
+            Ok(None) => {
+                if let Some(timer) = self.timers.get_mut(dialog_id) {
+                    timer.fail_refresh();
+                }
+                Err(anyhow!("re-INVITE timed out"))
+            }
+            Err(e) => {
+                if let Some(timer) = self.timers.get_mut(dialog_id) {
+                    timer.fail_refresh();
+                }
+                Err(e)
             }
         }
-
-        result.map(|_| ())
     }
 
     fn update_dialog_timer_from_headers(

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -162,6 +162,7 @@ impl SipSessionHandle {
 impl SipSession {
     pub const CALLER_TRACK_ID: &'static str = "caller-track";
     pub const CALLEE_TRACK_ID: &'static str = "callee-track";
+    const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(3);
 
     pub fn with_handle(id: SessionId) -> (SipSessionHandle, mpsc::UnboundedReceiver<CallCommand>) {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -414,7 +415,11 @@ impl SipSession {
         }
 
         let hangup_futures = FuturesUnordered::new();
+        let timeout = futures::future::pending::<()>().boxed();
+        let mut cancelled = false;
         tokio::pin!(hangup_futures);
+        tokio::pin!(timeout);
+
 
         loop {
             for dialog_id in self.pending_hangup.drain() {
@@ -427,15 +432,25 @@ impl SipSession {
                 }
             }
 
+            if cancelled
+                && hangup_futures.is_empty()
+                && self.pending_hangup.is_empty()
+                && self.server_dialog.state().is_terminated()
+                && self.callee_dialogs.is_empty()
+            {
+                break;
+            }
+
             tokio::select! {
                 res = hangup_futures.next(), if !hangup_futures.is_empty() => {
                     if let Some(res) = res {
                         tracing::info!("Hangup completed for dialog_id: {:?}", &res);
                     }
                 }
-                _ = self.cancel_token.cancelled() => {
-                    debug!(session_id = %self.context.session_id, "Session cancelled");
-                    break;
+                _ = self.cancel_token.cancelled(), if !cancelled => {
+                    debug!(session_id = %self.context.session_id, "Session cancellation observed");
+                    *timeout = tokio::time::sleep(Self::SHUTDOWN_DRAIN_TIMEOUT).boxed();
+                    cancelled = true;
                 }
 
 
@@ -460,8 +475,11 @@ impl SipSession {
                     }
                 }
 
+                _ = &mut timeout, if cancelled => {
+                    break;
+                }
 
-                Some(expired) = self.timer_queue.next(), if !self.timer_queue.is_empty() => {
+                Some(expired) = self.timer_queue.next(), if !cancelled && !self.timer_queue.is_empty() => {
                     let scheduled = expired.into_inner();
 
                     match self.next_timer_action(&scheduled) {
@@ -487,8 +505,7 @@ impl SipSession {
                         Some(TimerAction::Expired) => {
                             warn!(dialog_id = %scheduled, "Session timer expired, terminating session");
                             self.hangup_reason = Some(CallRecordHangupReason::Autohangup);
-                            self.cancel_token.cancel();
-                            break;
+                            self.pending_hangup.insert(scheduled);
                         }
                         None => {}
                     }
@@ -587,6 +604,13 @@ impl SipSession {
                         debug!(?reason, "Caller dialog terminated with reason");
                     }
                 }
+
+                let callee_ids: Vec<_> = self
+                    .callee_dialogs
+                    .iter()
+                    .map(|entry| entry.key().clone())
+                    .collect();
+                self.pending_hangup.extend(callee_ids);
                 self.cancel_token.cancel();
             }
             _ => {}
@@ -625,7 +649,6 @@ impl SipSession {
                 self.timers.remove(&terminated_dialog_id);
                 self.callee_guards
                     .retain(|guard| guard.id() != &terminated_dialog_id);
-                self.pending_hangup.insert(self.server_dialog.id());
 
                 match &reason {
                     TerminatedReason::UasBye => {
@@ -679,6 +702,8 @@ impl SipSession {
                             warn!(error = %e, "Failed to send rejection response to caller");
                         }
                     }
+                } else {
+                    self.pending_hangup.insert(self.server_dialog.id());
                 }
             }
             _ => {}


### PR DESCRIPTION
* use the registered address as request URI:
  * for extension, invite will use locator to find correct address, but cancel will not
* graceful hangup:
  * there are many place trying to call cancel,  and if that happens, the hangup may not complete
* session timer use UPDATE default, re-invite as an fallback