### PR TITLE
[codex] fix require-URI with registered address

### DIFF
--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -460,20 +460,21 @@ impl CallModule {
             }
         };
 
-        let mut loc = Location {
+        let loc = Location {
             aor: callee_uri.clone(),
             ..Default::default()
         };
+        let mut locs = vec![loc];
         let mut internal_lookup_empty = false;
 
         if callee_is_same_realm {
             if let Ok(results) = self.inner.server.locator.lookup(&callee_uri).await {
                 internal_lookup_empty = results.is_empty();
-                loc.supports_webrtc |= results.iter().any(|item| item.supports_webrtc);
+                if !results.is_empty() {
+                    locs = results;
+                }
             }
         }
-
-        let locs = vec![loc];
         let caller_uri = match caller.from.as_ref() {
             Some(uri) => uri.clone(),
             None => original
@@ -482,7 +483,6 @@ impl CallModule {
                 .uri()
                 .map_err(|e| RouteError::from((anyhow::anyhow!(e), None)))?,
         };
-
         let preview_option = InviteOption {
             callee: callee_uri.clone(),
             caller: caller_uri.clone(),


### PR DESCRIPTION
## What changed
This PR cherry-picks commit `0d2c049` onto `upstream/main` as a standalone change.

## Why
This keeps the fix isolated so it can be reviewed and merged independently from the other two recent changes.

## Impact
- narrows the change set to a single behavior change
- makes regression analysis and rollback simpler

## Root cause
Calls targeting a same-realm registered callee were still using the original AOR location instead of the resolved registered contact list, so the Request-URI could miss the registered address.

## Validation
- `cargo check` in an isolated branch based on `upstream/main`
