### PR TITLE
[codex] Fix media bridge SDP negotiation

### DIFF
--- a/src/media/negotiate.rs
+++ b/src/media/negotiate.rs
@@ -33,17 +33,30 @@ impl CodecInfo {
     /// Convert to rustrtc AudioCapability for use in RtcConfiguration.media_capabilities
     pub fn to_audio_capability(&self) -> Option<rustrtc::config::AudioCapability> {
         use rustrtc::config::AudioCapability;
-        match self.codec {
-            CodecType::PCMU => Some(AudioCapability::pcmu()),
-            CodecType::PCMA => Some(AudioCapability::pcma()),
-            CodecType::G722 => Some(AudioCapability::g722()),
-            CodecType::G729 => Some(AudioCapability::g729()),
+        let (codec_name, default_fmtp) = match self.codec {
+            CodecType::PCMU => ("PCMU".to_string(), None),
+            CodecType::PCMA => ("PCMA".to_string(), None),
+            CodecType::G722 => ("G722".to_string(), None),
+            CodecType::G729 => ("G729".to_string(), None),
             #[cfg(feature = "opus")]
-            CodecType::Opus => Some(AudioCapability::opus()),
-            CodecType::TelephoneEvent => Some(AudioCapability::telephone_event()),
+            CodecType::Opus => ("opus".to_string(), Some("minptime=10;useinbandfec=1".to_string())),
+            CodecType::TelephoneEvent => ("telephone-event".to_string(), Some("0-16".to_string())),
             #[allow(unreachable_patterns)]
-            _ => None,
-        }
+            _ => return None,
+        };
+
+        Some(AudioCapability {
+            payload_type: self.payload_type,
+            codec_name,
+            clock_rate: self.clock_rate,
+            channels: if self.channels > u8::MAX as u16 {
+                u8::MAX
+            } else {
+                self.channels as u8
+            },
+            fmtp: default_fmtp,
+            rtcp_fbs: vec![],
+        })
     }
 }
 
@@ -480,20 +493,17 @@ impl MediaNegotiator {
 
     /// Build codec lists for a transport bridge (WebRTC↔RTP).
     ///
-    /// Strategy (prefer no-transcoding):
-    /// 1. Use `allow_codecs` as the effective supported set (fall back to defaults if empty)
-    /// 2. Caller side: keep caller's offered codecs that are in both `effective` and
-    ///    transport-supported, preserving caller PT order
-    /// 3. Callee side: build from `effective` filtered by callee's transport support,
-    ///    with standard PT values
+    /// Strategy:
+    /// 1. Use the caller SDP as the source of truth for codec order and RTP params
+    /// 2. Filter caller side by caller transport support and optional `allow_codecs`
+    /// 3. Filter callee side by callee transport support and optional `allow_codecs`
+    /// 4. Preserve caller payload types and DTMF clock rates on both sides
     pub fn build_bridge_codec_lists(
         caller_sdp: &str,
         caller_is_webrtc: bool,
         callee_is_webrtc: bool,
         allow_codecs: &[CodecType],
     ) -> BridgeCodecLists {
-        let extracted = Self::extract_codec_params(caller_sdp);
-
         let caller_supported = if caller_is_webrtc {
             Self::default_webrtc_codecs()
         } else {
@@ -505,28 +515,26 @@ impl MediaNegotiator {
             Self::default_rtp_codecs()
         };
 
-        // Use allow_codecs if non-empty, otherwise fall back to union of both defaults
-        let effective: Vec<CodecType> = if allow_codecs.is_empty() {
-            let mut merged: Vec<CodecType> = Vec::new();
-            for c in caller_supported.iter().chain(callee_supported.iter()) {
-                if !merged.contains(c) {
-                    merged.push(*c);
-                }
-            }
-            merged
-        } else {
-            allow_codecs.to_vec()
-        };
+        let caller_codecs = Self::parse_audio_section(caller_sdp)
+            .map(|section| Self::extract_ordered_codecs_from_section(&section))
+            .unwrap_or_default();
 
-        // Caller side: keep caller's codecs that match both effective and caller_supported
-        let caller_side = Self::build_bridge_side_from_caller(
-            &extracted, &effective, &caller_supported,
-        );
+        let filtered_codecs: Vec<CodecInfo> = caller_codecs
+            .into_iter()
+            .filter(|codec| allow_codecs.is_empty() || allow_codecs.contains(&codec.codec))
+            .collect();
 
-        // Callee side: build from effective filtered by callee_supported
-        let callee_side = Self::build_bridge_side_from_allowed(
-            &effective, &callee_supported,
-        );
+        let caller_side: Vec<CodecInfo> = filtered_codecs
+            .iter()
+            .filter(|codec| caller_supported.contains(&codec.codec))
+            .cloned()
+            .collect();
+
+        let callee_side: Vec<CodecInfo> = filtered_codecs
+            .iter()
+            .filter(|codec| callee_supported.contains(&codec.codec))
+            .cloned()
+            .collect();
 
         BridgeCodecLists { caller_side, callee_side }
     }
@@ -1156,7 +1164,7 @@ a=rtpmap:101 telephone-event/8000\r\n";
         assert!(lists.callee_side.iter().any(|c| c.codec == CodecType::PCMU), "PCMU kept on WebRTC callee side");
     }
 
-    /// allow_codecs=[] → falls back to defaults, should include all default codecs
+    /// allow_codecs=[] → each side is filtered only by its own transport support.
     #[test]
     fn test_bridge_codecs_empty_allow_codecs_fallback() {
         let caller_sdp = "v=0\r\n\
@@ -1174,13 +1182,20 @@ a=rtpmap:101 telephone-event/8000\r\n";
             &[],   // empty allow_codecs
         );
 
-        // Caller side should have PCMU from caller SDP + more from defaults
-        assert!(lists.caller_side.iter().any(|c| c.codec == CodecType::PCMU));
-        // WebRTC callee side should have codecs too
-        assert!(lists.callee_side.iter().any(|c| c.codec == CodecType::PCMU));
+        let caller_audio: Vec<_> = lists.caller_side.iter()
+            .filter(|c| !c.is_dtmf())
+            .collect();
+        assert_eq!(caller_audio.len(), 1);
+        assert_eq!(caller_audio[0].codec, CodecType::PCMU);
+
+        let callee_audio: Vec<_> = lists.callee_side.iter()
+            .filter(|c| !c.is_dtmf())
+            .collect();
+        assert_eq!(callee_audio.len(), 1);
+        assert_eq!(callee_audio[0].codec, CodecType::PCMU);
     }
 
-    /// Caller offers PCMU at PT 0 → caller side preserves PT 0 (not reassigned)
+    /// Caller offers PCMU at PT 0 → both sides preserve caller PT 0.
     #[test]
     fn test_bridge_codecs_preserves_caller_payload_type() {
         let caller_sdp = "v=0\r\n\
@@ -1198,39 +1213,54 @@ a=rtpmap:101 telephone-event/8000\r\n";
             &[CodecType::PCMU, CodecType::TelephoneEvent],
         );
 
-        let pcmu = lists.caller_side.iter().find(|c| c.codec == CodecType::PCMU).unwrap();
-        assert_eq!(pcmu.payload_type, 0, "Should preserve caller's PT 0");
+        let caller_pcmu = lists.caller_side.iter().find(|c| c.codec == CodecType::PCMU).unwrap();
+        assert_eq!(caller_pcmu.payload_type, 0, "Caller side should preserve caller PT 0");
+
+        let callee_pcmu = lists.callee_side.iter().find(|c| c.codec == CodecType::PCMU).unwrap();
+        assert_eq!(callee_pcmu.payload_type, 0, "Callee side should preserve caller PT 0");
     }
 
-    /// Callee side uses standard PTs from codec definition, not from caller
+    /// DTMF payload types and sample rates must come from the caller SDP.
     #[test]
-    fn test_bridge_codecs_callee_side_uses_standard_pts() {
+    fn test_bridge_codecs_preserves_caller_dtmf_payload_types_and_rates() {
         let caller_sdp = "v=0\r\n\
 o=- 1 1 IN IP4 127.0.0.1\r\n\
 s=-\r\n\
 t=0 0\r\n\
-m=audio 10000 RTP/AVP 0 8 101\r\n\
-a=rtpmap:0 PCMU/8000\r\n\
-a=rtpmap:8 PCMA/8000\r\n\
-a=rtpmap:101 telephone-event/8000\r\n";
+m=audio 12345 UDP/TLS/RTP/SAVPF 111 101 110\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=rtpmap:101 telephone-event/8000\r\n\
+a=rtpmap:110 telephone-event/48000\r\n";
 
         let lists = MediaNegotiator::build_bridge_codec_lists(
             caller_sdp,
-            false, // caller is RTP
+            true,  // caller is WebRTC
             false, // callee is RTP
-            &[CodecType::PCMU, CodecType::PCMA, CodecType::TelephoneEvent],
+            &[CodecType::Opus, CodecType::TelephoneEvent],
         );
 
-        let callee_pcmu = lists.callee_side.iter().find(|c| c.codec == CodecType::PCMU).unwrap();
-        assert_eq!(callee_pcmu.payload_type, 0, "Callee PCMU should use standard PT 0");
+        let caller_dtmf: Vec<_> = lists.caller_side.iter()
+            .filter(|c| c.codec == CodecType::TelephoneEvent)
+            .collect();
+        assert_eq!(caller_dtmf.len(), 2);
+        assert_eq!(caller_dtmf[0].payload_type, 101);
+        assert_eq!(caller_dtmf[0].clock_rate, 8000);
+        assert_eq!(caller_dtmf[1].payload_type, 110);
+        assert_eq!(caller_dtmf[1].clock_rate, 48000);
 
-        let callee_pcma = lists.callee_side.iter().find(|c| c.codec == CodecType::PCMA).unwrap();
-        assert_eq!(callee_pcma.payload_type, 8, "Callee PCMA should use standard PT 8");
+        let callee_dtmf: Vec<_> = lists.callee_side.iter()
+            .filter(|c| c.codec == CodecType::TelephoneEvent)
+            .collect();
+        assert_eq!(callee_dtmf.len(), 2);
+        assert_eq!(callee_dtmf[0].payload_type, 101);
+        assert_eq!(callee_dtmf[0].clock_rate, 8000);
+        assert_eq!(callee_dtmf[1].payload_type, 110);
+        assert_eq!(callee_dtmf[1].clock_rate, 48000);
     }
 
     /// Reverse direction: RTP caller → WebRTC callee
     /// Caller offers PCMA first, allow_codecs=[Opus,PCMU,PCMA] →
-    /// callee side (WebRTC) should have all three, caller side preserves caller order
+    /// both sides keep only caller-offered codecs that pass the per-leg filters.
     #[test]
     fn test_bridge_codecs_rtp_caller_webrtc_callee() {
         let caller_sdp = "v=0\r\n\
@@ -1254,19 +1284,19 @@ a=rtpmap:101 telephone-event/8000\r\n";
             ],
         );
 
-        // Caller side: PCMA first (caller's order), then PCMU, then Opus appended
         let caller_audio: Vec<_> = lists.caller_side.iter()
             .filter(|c| !c.is_dtmf()).collect();
         assert_eq!(caller_audio[0].codec, CodecType::PCMA, "Caller side preserves PCMA first from caller SDP");
         assert_eq!(caller_audio[1].codec, CodecType::PCMU);
-        assert_eq!(caller_audio[2].codec, CodecType::Opus, "Opus appended from allow_codecs");
+        assert_eq!(caller_audio.len(), 2);
+        assert!(!lists.caller_side.iter().any(|c| c.codec == CodecType::Opus));
 
-        // Callee side: Opus, PCMU, PCMA per allow_codecs order
         let callee_audio: Vec<_> = lists.callee_side.iter()
             .filter(|c| !c.is_dtmf()).collect();
-        assert_eq!(callee_audio[0].codec, CodecType::Opus);
+        assert_eq!(callee_audio[0].codec, CodecType::PCMA);
         assert_eq!(callee_audio[1].codec, CodecType::PCMU);
-        assert_eq!(callee_audio[2].codec, CodecType::PCMA);
+        assert_eq!(callee_audio.len(), 2);
+        assert!(!lists.callee_side.iter().any(|c| c.codec == CodecType::Opus));
     }
 
     /// to_audio_capability converts all known codecs

--- a/src/media/negotiate.rs
+++ b/src/media/negotiate.rs
@@ -380,6 +380,43 @@ impl MediaNegotiator {
         }
     }
 
+    fn attr_payload_type(attr: &rustrtc::sdp::Attribute) -> Option<u8> {
+        let value = attr.value.as_ref()?;
+        value.split_whitespace().next()?.parse::<u8>().ok()
+    }
+
+    /// Restrict an already-generated SDP answer to the negotiated audio profile
+    /// selected by the opposite leg. This keeps the bridge PCs intact while
+    /// forcing the remote endpoint to send the codec the callee actually accepted.
+    pub fn restrict_audio_answer_to_profile(
+        answer_sdp: &str,
+        profile: &NegotiatedLegProfile,
+    ) -> Option<String> {
+        let selected_audio = profile.audio.as_ref()?;
+
+        let mut allowed_pts = vec![selected_audio.payload_type];
+        if let Some(dtmf) = profile.dtmf.as_ref() {
+            if !allowed_pts.contains(&dtmf.payload_type) {
+                allowed_pts.push(dtmf.payload_type);
+            }
+        }
+
+        let mut desc = SessionDescription::parse(SdpType::Answer, answer_sdp).ok()?;
+        let audio_section = desc
+            .media_sections
+            .iter_mut()
+            .find(|section| section.kind == MediaKind::Audio)?;
+
+        audio_section.formats = allowed_pts.iter().map(|pt| pt.to_string()).collect();
+        audio_section.attributes.retain(|attr| match attr.key.as_str() {
+            "rtpmap" | "fmtp" | "rtcp-fb" => Self::attr_payload_type(attr)
+                .is_none_or(|pt| allowed_pts.contains(&pt)),
+            _ => true,
+        });
+
+        Some(desc.to_sdp_string())
+    }
+
     /// Build codec list for callee offer in anchored media mode.
     ///
     /// Strategy:
@@ -1297,6 +1334,52 @@ a=rtpmap:101 telephone-event/8000\r\n";
         assert_eq!(callee_audio[1].codec, CodecType::PCMU);
         assert_eq!(callee_audio.len(), 2);
         assert!(!lists.callee_side.iter().any(|c| c.codec == CodecType::Opus));
+    }
+
+    #[test]
+    fn test_restrict_audio_answer_to_profile_keeps_only_selected_codec_and_dtmf() {
+        let answer_sdp = "v=0\r\n\
+o=- 1 1 IN IP4 127.0.0.1\r\n\
+s=-\r\n\
+t=0 0\r\n\
+m=audio 9 UDP/TLS/RTP/SAVPF 111 9 0 8 110 126\r\n\
+c=IN IP4 0.0.0.0\r\n\
+a=mid:0\r\n\
+a=sendrecv\r\n\
+a=rtcp-mux\r\n\
+a=rtpmap:111 opus/48000/2\r\n\
+a=fmtp:111 minptime=10;useinbandfec=1\r\n\
+a=rtpmap:9 G722/8000\r\n\
+a=rtpmap:0 PCMU/8000\r\n\
+a=rtpmap:8 PCMA/8000\r\n\
+a=rtpmap:110 telephone-event/48000\r\n\
+a=fmtp:110 0-16\r\n\
+a=rtpmap:126 telephone-event/8000\r\n\
+a=fmtp:126 0-16\r\n";
+
+        let profile = NegotiatedLegProfile {
+            audio: Some(NegotiatedCodec {
+                codec: CodecType::G722,
+                payload_type: 9,
+                clock_rate: 8000,
+                channels: 1,
+            }),
+            dtmf: Some(NegotiatedCodec {
+                codec: CodecType::TelephoneEvent,
+                payload_type: 126,
+                clock_rate: 8000,
+                channels: 1,
+            }),
+        };
+
+        let filtered =
+            MediaNegotiator::restrict_audio_answer_to_profile(answer_sdp, &profile).unwrap();
+
+        assert!(filtered.contains("m=audio 9 UDP/TLS/RTP/SAVPF 9 126"));
+        assert!(filtered.contains("a=rtpmap:9 G722/8000"));
+        assert!(filtered.contains("a=rtpmap:126 telephone-event/8000"));
+        assert!(!filtered.contains("a=rtpmap:111 opus/48000/2"));
+        assert!(!filtered.contains("a=rtpmap:110 telephone-event/48000"));
     }
 
     /// to_audio_capability converts all known codecs

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -1390,6 +1390,8 @@ impl SipSession {
                 if let Some(ref bridge) = self.media_bridge {
                     use rustrtc::sdp::{SdpType, SessionDescription};
 
+                    let callee_profile = MediaNegotiator::extract_leg_profile(sdp);
+
                     // 1. Set callee's RTP answer on bridge's RTP side
                     debug!(session_id = %self.context.session_id, "Bridge: Setting RTP side remote from callee answer");
                     if let Ok(desc) = SessionDescription::parse(SdpType::Answer, sdp) {
@@ -1424,6 +1426,13 @@ impl SipSession {
                                                         .webrtc_pc()
                                                         .local_description()
                                                         .map(|d| d.to_sdp_string())
+                                                        .map(|answer_sdp| {
+                                                            MediaNegotiator::restrict_audio_answer_to_profile(
+                                                                &answer_sdp,
+                                                                &callee_profile,
+                                                            )
+                                                            .unwrap_or(answer_sdp)
+                                                        })
                                                         .or_else(|| callee_sdp.clone())
                                                 }
                                             }

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -1463,7 +1463,7 @@ impl SipSession {
                     use rustrtc::sdp::{SdpType, SessionDescription};
 
                     // 1. Set callee's WebRTC answer on bridge's WebRTC side
-                    debug!(session_id = %self.context.session_id, "Bridge: Setting WebRTC side remote from callee answer");
+                    debug!(session_id = %self.context.session_id, sdp= %sdp, "Bridge: Setting WebRTC side remote from callee answer");
                     if let Ok(desc) = SessionDescription::parse(SdpType::Answer, sdp) {
                         if let Err(e) = bridge.webrtc_pc().set_remote_description(desc).await {
                             warn!(session_id = %self.context.session_id, error = %e, "Failed to set bridge WebRTC remote description");


### PR DESCRIPTION
## What changed

This PR tightens SDP negotiation for the WebRTC <-> RTP media bridge.

- update bridge codec list construction so each leg is filtered from the caller-offer codec set by per-leg transport support and optional `allow_codecs`
- preserve codec metadata when converting negotiated codecs into bridge audio capabilities
- restrict the caller-facing WebRTC answer to the callee-negotiated audio profile in the WebRTC-caller -> RTP-callee bridge path

## Why

The bridge was building codec lists that could advertise or prefer codecs more broadly than the final negotiated leg actually used. In practice this made SDP negotiation confusing and, in earlier investigations, made it look like the RTP leg might send the wrong codec.

The key root cause addressed here is that the bridge answer sent back to the WebRTC caller was not constrained to the codec actually selected by the RTP callee. That allowed the caller side to keep a broader audio set than the far RTP leg had really negotiated.

## Impact

- keeps bridge codec ordering/filtering closer to the caller offer and per-leg transport support
- preserves payload-type and clock-rate information from negotiated codec entries
- narrows the WebRTC caller answer to the RTP callee's selected audio codec plus DTMF, reducing negotiation mismatch in bridge calls

## Validation

- `cargo test --lib bridge_codecs -- --nocapture`
- `cargo test --lib test_restrict_audio_answer_to_profile_keeps_only_selected_codec_and_dtmf -- --nocapture`
- `cargo test --lib test_bridge_with_custom_sender_codecs -- --nocapture`
