### PR TITLE
[codex] Use prebuilt cross images for both Docker CI targets

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,15 +29,19 @@ jobs:
         with:
           tool: cross
 
-      - name: Build Binaries
+      - name: Build AMD64 Binaries
         run: |
-          cross build --release --target x86_64-unknown-linux-gnu --features cross
-          cross build --release --target aarch64-unknown-linux-gnu --features cross
+          cross build --release --target x86_64-unknown-linux-gnu --features cross --bin rustpbx --bin sipflow
 
-          # Organize binaries for Docker Packaging
-          mkdir -p bin/amd64 bin/arm64
+          mkdir -p bin/amd64
           cp target/x86_64-unknown-linux-gnu/release/rustpbx bin/amd64/
           cp target/x86_64-unknown-linux-gnu/release/sipflow bin/amd64/
+
+      - name: Build ARM64 Binaries
+        run: |
+          cross build --release --target aarch64-unknown-linux-gnu --features cross --bin rustpbx --bin sipflow
+
+          mkdir -p bin/arm64
           cp target/aarch64-unknown-linux-gnu/release/rustpbx bin/arm64/
           cp target/aarch64-unknown-linux-gnu/release/sipflow bin/arm64/
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,11 +12,10 @@ env:
   IMAGE_NAME: restsend/rustpbx
 
 jobs:
-  build:
+  build-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +36,29 @@ jobs:
           cp target/x86_64-unknown-linux-gnu/release/rustpbx bin/amd64/
           cp target/x86_64-unknown-linux-gnu/release/sipflow bin/amd64/
 
+      - name: Upload AMD64 Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-amd64
+          path: bin/amd64
+          if-no-files-found: error
+
+  build-arm64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
       - name: Build ARM64 Binaries
         run: |
           cross build --release --target aarch64-unknown-linux-gnu --features cross --bin rustpbx --bin sipflow
@@ -44,6 +66,37 @@ jobs:
           mkdir -p bin/arm64
           cp target/aarch64-unknown-linux-gnu/release/rustpbx bin/arm64/
           cp target/aarch64-unknown-linux-gnu/release/sipflow bin/arm64/
+
+      - name: Upload ARM64 Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-arm64
+          path: bin/arm64
+          if-no-files-found: error
+
+  docker-image:
+    runs-on: ubuntu-latest
+    needs:
+      - build-amd64
+      - build-arm64
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download AMD64 Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: bin-amd64
+          path: bin/amd64
+
+      - name: Download ARM64 Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: bin-arm64
+          path: bin/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
-dockerfile = "./Dockerfile.cross-x86_64"
+image = "ghcr.io/miuda-ai/rustpbx-cross-x86_64:latest"
 
 [target.aarch64-unknown-linux-gnu]
-dockerfile = "./Dockerfile.cross-aarch64"
+image = "ghcr.io/miuda-ai/rustpbx-cross-aarch64:latest"


### PR DESCRIPTION
## What changed

- switch `Cross.toml` to use prebuilt GHCR images for both `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`
- keep both architectures on `cross build` in the main Docker workflow
- split `amd64` and `arm64` into separate parallel jobs
- add a final Docker packaging job that waits for both build artifacts

## Why

The main CI bottleneck was rebuilding custom `cross` Docker images and running large `apt-get` installs during every workflow run. This change reuses prebuilt images published from `miuda-ai/rustpbx-cross-images`, so normal `rustpbx` CI can go straight to `cross build` for both targets.

## Dependency

This PR expects these images to exist and be pullable:

- `ghcr.io/miuda-ai/rustpbx-cross-x86_64:latest`
- `ghcr.io/miuda-ai/rustpbx-cross-aarch64:latest`

Source repository:

- `https://github.com/miuda-ai/rustpbx-cross-images`

## Validation

- validated workflow YAML parses successfully
- checked the workflow diff with `git diff --check`
- this branch contains only CI config changes
