### PR TITLE
[codex] Fix docker binary permissions for packaged artifacts

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross
-
       - name: Build ARM64 Binaries
         run: |
           cross build --release --target aarch64-unknown-linux-gnu --features cross --bin rustpbx --bin sipflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN mkdir -p /app/config /app/sounds /app/templates
 # Automatically pick the correct binary based on the architecture being built
 # We expect binaries to be placed in bin/amd64/ and bin/arm64/ by the build script
 ARG TARGETARCH
-COPY bin/${TARGETARCH}/rustpbx /app/rustpbx
-COPY bin/${TARGETARCH}/sipflow /app/sipflow
+COPY --chmod=0755 bin/${TARGETARCH}/rustpbx /app/rustpbx
+COPY --chmod=0755 bin/${TARGETARCH}/sipflow /app/sipflow
 
 # Copy static resources
 COPY ./static /app/static


### PR DESCRIPTION
## What changed

- Set executable permission for packaged binaries in `Dockerfile` using explicit mode (`COPY --chmod=0755`).
- Keeps build outputs runnable after artifact transfer in parallel CI jobs.

This PR is a minimal follow-up after the prebuilt cross image workflow changes.
