### PR TITLE
Refine SIP session timer negotiation behavior

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -56,6 +56,8 @@ udp_port = 15060
 registrar_expires = 60
 ws_handler= "/ws"
 media_proxy = "auto"
+# session_timer = true
+# session_timer_always = false # Keep refreshing even if peer does not negotiate session timer
 # Base directory for generated routing/trunk/ACL files
 generated_dir = "./config"
 routes_files = ["config/routes/*.toml"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -701,6 +701,23 @@ impl Default for MediaProxyMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTimerMode {
+    Off,
+    Supported,
+    Always,
+}
+
+impl SessionTimerMode {
+    pub fn is_enabled(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    pub fn is_always(self) -> bool {
+        matches!(self, Self::Always)
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct RtpConfig {
     pub external_ip: Option<String>,
@@ -773,6 +790,8 @@ pub struct ProxyConfig {
     pub routes: Option<Vec<RouteRule>>,
     #[serde(default)]
     pub session_timer: bool,
+    #[serde(default)]
+    pub session_timer_always: bool,
     #[serde(default)]
     pub session_expires: Option<u64>,
     #[serde(default)]
@@ -869,6 +888,16 @@ impl Default for AmiConfig {
 }
 
 impl ProxyConfig {
+    pub fn session_timer_mode(&self) -> SessionTimerMode {
+        if !self.session_timer {
+            SessionTimerMode::Off
+        } else if self.session_timer_always {
+            SessionTimerMode::Always
+        } else {
+            SessionTimerMode::Supported
+        }
+    }
+
     pub fn normalize_realm(realm: &str) -> &str {
         let realm = if let Some(pos) = realm.find(':') {
             &realm[..pos]
@@ -995,6 +1024,7 @@ impl Default for ProxyConfig {
             acl_files: Vec::new(),
             routes: None,
             session_timer: false,
+            session_timer_always: false,
             session_expires: None,
             queues: HashMap::new(),
             queues_files: Vec::new(),
@@ -1255,5 +1285,39 @@ mod tests {
         assert_eq!(config.select_realm("other.com"), "example.com");
         // No match with port, return first realm if configured
         assert_eq!(config.select_realm("other.com:5060"), "example.com");
+    }
+
+    #[test]
+    fn test_session_timer_mode_defaults_to_supported_when_enabled() {
+        #[derive(Deserialize)]
+        struct SessionTimerWrapper {
+            session_timer: bool,
+            #[serde(default)]
+            session_timer_always: bool,
+        }
+
+        let disabled: SessionTimerWrapper = toml::from_str("session_timer=false").unwrap();
+        assert!(!disabled.session_timer);
+        assert!(!disabled.session_timer_always);
+
+        let enabled: SessionTimerWrapper = toml::from_str("session_timer=true").unwrap();
+        assert!(enabled.session_timer);
+        assert!(!enabled.session_timer_always);
+    }
+
+    #[test]
+    fn test_session_timer_mode_uses_always_flag() {
+        let mut config = ProxyConfig::default();
+
+        assert_eq!(config.session_timer_mode(), SessionTimerMode::Off);
+
+        config.session_timer = true;
+        assert_eq!(config.session_timer_mode(), SessionTimerMode::Supported);
+
+        config.session_timer_always = true;
+        assert_eq!(config.session_timer_mode(), SessionTimerMode::Always);
+
+        config.session_timer = false;
+        assert_eq!(config.session_timer_mode(), SessionTimerMode::Off);
     }
 }

--- a/src/proxy/proxy_call/session_timer.rs
+++ b/src/proxy/proxy_call/session_timer.rs
@@ -4,6 +4,7 @@
 //! Session timers are used to detect and recover from hung SIP sessions
 //! by requiring periodic session refresh requests.
 
+use crate::config::SessionTimerMode;
 use anyhow::{Result, anyhow};
 use std::str::FromStr;
 use std::time::Duration;
@@ -54,6 +55,14 @@ impl FromStr for SessionRefresher {
 }
 
 impl SessionRefresher {
+    pub fn for_local_role(we_are_uac: bool) -> Self {
+        if we_are_uac {
+            SessionRefresher::Uac
+        } else {
+            SessionRefresher::Uas
+        }
+    }
+
     /// Check if we are the refresher based on our role
     pub fn is_our_role(&self, we_are_uac: bool) -> bool {
         matches!(
@@ -66,6 +75,8 @@ impl SessionRefresher {
 /// Session timer state machine
 #[derive(Debug, Clone)]
 pub struct SessionTimerState {
+    /// Session timer policy for this dialog
+    pub mode: SessionTimerMode,
     /// Timer is enabled (negotiated via Session-Expires header)
     pub enabled: bool,
     /// Session expiration interval
@@ -92,6 +103,7 @@ pub struct SessionTimerState {
 impl Default for SessionTimerState {
     fn default() -> Self {
         Self {
+            mode: SessionTimerMode::Off,
             enabled: false,
             session_interval: Duration::from_secs(DEFAULT_SESSION_EXPIRES),
             min_se: Duration::from_secs(MIN_MIN_SE),
@@ -112,6 +124,7 @@ impl SessionTimerState {
     #[cfg(test)]
     pub fn new(session_interval: Duration, min_se: Duration, refresher: SessionRefresher) -> Self {
         Self {
+            mode: SessionTimerMode::Supported,
             enabled: true,
             session_interval,
             min_se,
@@ -359,15 +372,24 @@ pub fn parse_min_se(value: &str) -> Option<Duration> {
     Some(Duration::from_secs(seconds))
 }
 
-pub fn select_timer_refresher(
+pub fn select_server_timer_refresher(
     peer_supports_timer: bool,
+    session_expires_present: bool,
     requested_refresher: Option<SessionRefresher>,
 ) -> SessionRefresher {
-    if peer_supports_timer {
-        requested_refresher.unwrap_or(SessionRefresher::Uac)
+    if let Some(refresher) = requested_refresher {
+        refresher
+    } else if peer_supports_timer && session_expires_present {
+        SessionRefresher::Uac
     } else {
         SessionRefresher::Uas
     }
+}
+
+pub fn select_client_timer_refresher(
+    requested_refresher: Option<SessionRefresher>,
+) -> SessionRefresher {
+    requested_refresher.unwrap_or(SessionRefresher::Uac)
 }
 
 pub fn apply_session_timer_headers(
@@ -397,11 +419,18 @@ pub fn apply_session_timer_headers(
 pub fn apply_refresh_response(
     timer: &mut SessionTimerState,
     headers: &rsipstack::sip::Headers,
+    we_are_uac: bool,
 ) -> Result<()> {
     if get_header_value(headers, HEADER_SESSION_EXPIRES).is_none() {
         timer.complete_refresh();
-        timer.enabled = false;
-        timer.active = false;
+        if timer.mode.is_always() {
+            // Keep the local side responsible for refreshes when always mode is forcing
+            // session timers but the peer omits Session-Expires in a successful refresh.
+            timer.refresher = SessionRefresher::for_local_role(we_are_uac);
+        } else {
+            timer.enabled = false;
+            timer.active = false;
+        }
         return Ok(());
     }
 
@@ -457,20 +486,11 @@ pub fn build_session_timer_headers(
     )
 }
 
-pub fn build_session_timer_response_headers(
-    timer: &SessionTimerState,
-    peer_supports_timer: bool,
-) -> Vec<rsipstack::sip::Header> {
-    let mut headers = vec![rsipstack::sip::Header::Other(
+pub fn build_session_timer_response_headers(timer: &SessionTimerState) -> Vec<rsipstack::sip::Header> {
+    vec![rsipstack::sip::Header::Other(
         HEADER_SESSION_EXPIRES.to_string(),
         timer.get_session_expires_value(),
-    )];
-    if peer_supports_timer && timer.refresher == SessionRefresher::Uac {
-        headers.push(rsipstack::sip::Header::Require(
-            rsipstack::sip::headers::Require::from(TIMER_TAG),
-        ));
-    }
-    headers
+    )]
 }
 
 /// Check if timer is required (Require: timer header)

--- a/src/proxy/proxy_call/session_timer_tests.rs
+++ b/src/proxy/proxy_call/session_timer_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::config::SessionTimerMode;
     use crate::proxy::proxy_call::session_timer::*;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
@@ -39,6 +40,7 @@ mod tests {
     #[test]
     fn test_session_timer_state_memory() {
         let timer = Arc::new(Mutex::new(SessionTimerState {
+            mode: SessionTimerMode::Supported,
             enabled: true,
             active: true,
             refresher: SessionRefresher::Uas,
@@ -382,6 +384,7 @@ mod tests {
     #[test]
     fn test_session_timer_expiration_logic() {
         let mut timer = SessionTimerState {
+            mode: SessionTimerMode::Supported,
             enabled: true,
             active: true,
             refresher: SessionRefresher::Uas,
@@ -407,6 +410,7 @@ mod tests {
     #[test]
     fn test_session_timer_refresh_logic() {
         let mut timer = SessionTimerState {
+            mode: SessionTimerMode::Supported,
             enabled: true,
             active: true,
             refresher: SessionRefresher::Uas,
@@ -926,17 +930,16 @@ mod tests {
     }
 
     #[test]
-    fn test_build_session_timer_response_headers_require_timer_for_uac_refresher() {
+    fn test_build_session_timer_response_headers_do_not_require_timer_for_uac_refresher() {
         let mut timer = SessionTimerState::default();
         timer.enabled = true;
         timer.active = true;
         timer.refresher = SessionRefresher::Uac;
         timer.session_interval = Duration::from_secs(1800);
 
-        let headers =
-            rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer, true));
+        let headers = rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer));
 
-        assert!(is_timer_required(&headers));
+        assert!(!is_timer_required(&headers));
         assert_eq!(
             get_header_value(&headers, HEADER_SESSION_EXPIRES),
             Some("1800;refresher=uac".to_string())
@@ -951,8 +954,7 @@ mod tests {
         timer.refresher = SessionRefresher::Uas;
         timer.session_interval = Duration::from_secs(1800);
 
-        let headers =
-            rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer, true));
+        let headers = rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer));
 
         assert!(!is_timer_required(&headers));
     }
@@ -965,8 +967,7 @@ mod tests {
         timer.refresher = SessionRefresher::Uac;
         timer.session_interval = Duration::from_secs(1800);
 
-        let headers =
-            rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer, false));
+        let headers = rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer));
 
         assert!(!is_timer_required(&headers));
     }
@@ -991,8 +992,7 @@ mod tests {
         timer.refresher = SessionRefresher::Uas;
         timer.session_interval = Duration::from_secs(1800);
 
-        let headers =
-            rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer, true));
+        let headers = rsipstack::sip::Headers::from(build_session_timer_response_headers(&timer));
 
         assert_eq!(
             get_header_value(&headers, HEADER_SESSION_EXPIRES),
@@ -1003,19 +1003,42 @@ mod tests {
     }
 
     #[test]
-    fn test_select_timer_refresher_defaults_to_uas_without_timer_support() {
-        assert_eq!(select_timer_refresher(false, None), SessionRefresher::Uas);
+    fn test_select_server_timer_refresher_defaults_to_uas_without_timer_support() {
         assert_eq!(
-            select_timer_refresher(false, Some(SessionRefresher::Uac)),
+            select_server_timer_refresher(false, true, None),
+            SessionRefresher::Uas
+        );
+        assert_eq!(
+            select_server_timer_refresher(false, true, Some(SessionRefresher::Uac)),
+            SessionRefresher::Uac
+        );
+    }
+
+    #[test]
+    fn test_select_server_timer_refresher_uses_request_when_peer_supports_timer() {
+        assert_eq!(
+            select_server_timer_refresher(true, true, None),
+            SessionRefresher::Uac
+        );
+        assert_eq!(
+            select_server_timer_refresher(true, true, Some(SessionRefresher::Uas)),
             SessionRefresher::Uas
         );
     }
 
     #[test]
-    fn test_select_timer_refresher_uses_request_when_peer_supports_timer() {
-        assert_eq!(select_timer_refresher(true, None), SessionRefresher::Uac);
+    fn test_select_server_timer_refresher_defaults_to_uas_without_session_expires() {
         assert_eq!(
-            select_timer_refresher(true, Some(SessionRefresher::Uas)),
+            select_server_timer_refresher(true, false, None),
+            SessionRefresher::Uas
+        );
+    }
+
+    #[test]
+    fn test_select_client_timer_refresher_defaults_to_uac() {
+        assert_eq!(select_client_timer_refresher(None), SessionRefresher::Uac);
+        assert_eq!(
+            select_client_timer_refresher(Some(SessionRefresher::Uas)),
             SessionRefresher::Uas
         );
     }
@@ -1023,18 +1046,61 @@ mod tests {
     #[test]
     fn test_apply_refresh_response_disables_timer_without_session_expires() {
         let mut timer = SessionTimerState::default();
+        timer.mode = SessionTimerMode::Supported;
         timer.enabled = true;
         timer.active = true;
         timer.refreshing = true;
         timer.session_interval = Duration::from_secs(1800);
 
         let headers = rsipstack::sip::Headers::default();
-        let result = apply_refresh_response(&mut timer, &headers);
+        let result = apply_refresh_response(&mut timer, &headers, false);
 
         assert!(result.is_ok());
         assert!(!timer.enabled);
         assert!(!timer.active);
         assert!(!timer.refreshing);
+        assert_eq!(timer.refresh_count, 1);
+    }
+
+    #[test]
+    fn test_apply_refresh_response_keeps_local_uas_without_session_expires_in_always_mode() {
+        let mut timer = SessionTimerState::default();
+        timer.mode = SessionTimerMode::Always;
+        timer.enabled = true;
+        timer.active = true;
+        timer.refreshing = true;
+        timer.refresher = SessionRefresher::Uas;
+        timer.session_interval = Duration::from_secs(1800);
+
+        let headers = rsipstack::sip::Headers::default();
+        let result = apply_refresh_response(&mut timer, &headers, false);
+
+        assert!(result.is_ok());
+        assert!(timer.enabled);
+        assert!(timer.active);
+        assert!(!timer.refreshing);
+        assert_eq!(timer.refresher, SessionRefresher::Uas);
+        assert_eq!(timer.refresh_count, 1);
+    }
+
+    #[test]
+    fn test_apply_refresh_response_keeps_local_uac_without_session_expires_in_always_mode() {
+        let mut timer = SessionTimerState::default();
+        timer.mode = SessionTimerMode::Always;
+        timer.enabled = true;
+        timer.active = true;
+        timer.refreshing = true;
+        timer.refresher = SessionRefresher::Uas;
+        timer.session_interval = Duration::from_secs(1800);
+
+        let headers = rsipstack::sip::Headers::default();
+        let result = apply_refresh_response(&mut timer, &headers, true);
+
+        assert!(result.is_ok());
+        assert!(timer.enabled);
+        assert!(timer.active);
+        assert!(!timer.refreshing);
+        assert_eq!(timer.refresher, SessionRefresher::Uac);
         assert_eq!(timer.refresh_count, 1);
     }
 
@@ -1051,7 +1117,7 @@ mod tests {
             HEADER_SESSION_EXPIRES.to_string(),
             "900;refresher=uas".to_string(),
         )]);
-        let result = apply_refresh_response(&mut timer, &headers);
+        let result = apply_refresh_response(&mut timer, &headers, false);
 
         assert!(result.is_ok());
         assert!(timer.enabled);

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -41,7 +41,8 @@ use crate::proxy::proxy_call::{
         SessionRefresher, SessionTimerState, apply_refresh_response,
         apply_session_timer_headers, build_default_session_timer_headers,
         build_session_timer_headers, build_session_timer_response_headers, get_header_value,
-        has_timer_support, parse_min_se, parse_session_expires, select_timer_refresher,
+        has_timer_support, parse_min_se, parse_session_expires, select_client_timer_refresher,
+        select_server_timer_refresher,
     },
     state::{CallContext, CallSessionRecordSnapshot, SessionHangupMessage},
 };
@@ -736,10 +737,7 @@ impl SipSession {
                 )]
             })
         } else {
-            self.successful_refresh_response_headers(
-                &dialog_id,
-                has_timer_support(&request.headers),
-            )
+            self.successful_refresh_response_headers(&dialog_id)
         }
         .unwrap_or_default();
 
@@ -1284,7 +1282,7 @@ impl SipSession {
             .proxy_config
             .session_expires
             .unwrap_or(DEFAULT_SESSION_EXPIRES);
-        if self.server.proxy_config.session_timer {
+        if self.server.proxy_config.session_timer_mode().is_enabled() {
             headers.extend(build_default_session_timer_headers(
                 default_expires,
                 MIN_MIN_SE,
@@ -1366,7 +1364,7 @@ impl SipSession {
                     break match res {
                         Ok((dialog, response)) => {
                             if let Some(ref resp) = response {
-                                if self.server.proxy_config.session_timer
+                                if self.server.proxy_config.session_timer_mode().is_enabled()
                                     && resp.status_code == StatusCode::SessionIntervalTooSmall
                                     && retry_count < 1
                                 {
@@ -1505,9 +1503,22 @@ impl SipSession {
         .map_err(|e| (StatusCode::ServerInternalError, Some(e.to_string())))?;
 
         self.callee_dialogs.insert(dialog_id.clone(), ());
-        if self.server.proxy_config.session_timer {
+        if self.server.proxy_config.session_timer_mode().is_enabled() {
             if let Some(ref response) = response {
-                self.init_callee_timer(dialog_id.clone(), response, default_expires);
+                let requested_session_interval = invite_option
+                    .headers
+                    .as_ref()
+                    .and_then(|headers| {
+                        headers
+                            .iter()
+                            .find(|header| header.name().eq_ignore_ascii_case(HEADER_SESSION_EXPIRES))
+                            .map(|header| header.value().to_string())
+                    })
+                    .as_deref()
+                    .and_then(parse_session_expires)
+                    .map(|(interval, _)| interval)
+                    .unwrap_or_else(|| Duration::from_secs(default_expires));
+                self.init_callee_timer(dialog_id.clone(), response, requested_session_interval);
             }
         }
         self.callee_guards.push(ClientDialogGuard::new(
@@ -2431,7 +2442,7 @@ impl SipSession {
         self.connected_callee = callee.clone();
 
         let mut timer_headers = vec![];
-        if self.server.proxy_config.session_timer {
+        if self.server.proxy_config.session_timer_mode().is_enabled() {
             let default_expires = self
                 .server
                 .proxy_config
@@ -2442,12 +2453,7 @@ impl SipSession {
                     let caller_dialog_id = self.caller_dialog_id();
                     if let Some(timer) = self.timers.get(&caller_dialog_id) {
                         if timer.enabled {
-                            let caller_supports_timer =
-                                has_timer_support(&self.server_dialog.initial_request().headers);
-                            timer_headers.extend(build_session_timer_response_headers(
-                                timer,
-                                caller_supports_timer,
-                            ));
+                            timer_headers.extend(build_session_timer_response_headers(timer));
                             debug!(
                                 session_expires = %timer.get_session_expires_value(),
                                 "Session timer negotiated in 200 OK"
@@ -2716,10 +2722,8 @@ impl SipSession {
                 "application/sdp".into(),
             )];
             let caller_dialog_id = self.caller_dialog_id();
-            if let Some(timer_headers) = self.successful_refresh_response_headers(
-                &caller_dialog_id,
-                has_timer_support(&self.server_dialog.initial_request().headers),
-            ) {
+            if let Some(timer_headers) = self.successful_refresh_response_headers(&caller_dialog_id)
+            {
                 headers.extend(timer_headers);
             }
             self.server_dialog
@@ -2928,31 +2932,41 @@ impl SipSession {
         let request = self.server_dialog.initial_request();
         let headers = &request.headers;
         let dialog_id = self.caller_dialog_id();
+        let session_timer_mode = self.server.proxy_config.session_timer_mode();
 
         let supported = has_timer_support(headers);
         let session_expires_value = get_header_value(headers, HEADER_SESSION_EXPIRES);
         let mut timer = SessionTimerState::default();
+        timer.mode = session_timer_mode;
 
-        let local_min_se = Duration::from_secs(MIN_MIN_SE);
+        if let Some(min_se) = get_header_value(headers, HEADER_MIN_SE)
+            .as_deref()
+            .and_then(parse_min_se)
+        {
+            if timer.min_se < min_se {
+                timer.min_se = min_se;
+            }
+        }
+
         if let Some(value) = session_expires_value {
             if let Some((interval, refresher)) = parse_session_expires(&value) {
-                if interval < local_min_se {
+                if interval < timer.min_se {
                     return Err((
                         StatusCode::SessionIntervalTooSmall,
-                        Some(local_min_se.as_secs().to_string()),
+                        Some(timer.min_se.as_secs().to_string()),
                     ));
                 }
 
                 timer.enabled = true;
                 timer.session_interval = interval;
                 timer.active = true;
-                timer.refresher = select_timer_refresher(supported, refresher);
+                timer.refresher = select_server_timer_refresher(supported, true, refresher);
             }
-        } else {
+        } else if session_timer_mode.is_always() {
             timer.enabled = true;
-            timer.session_interval = Duration::from_secs(default_expires);
+            timer.session_interval = Duration::from_secs(default_expires).max(timer.min_se);
             timer.active = true;
-            timer.refresher = select_timer_refresher(supported, None);
+            timer.refresher = select_server_timer_refresher(supported, false, None);
         }
 
         self.timers.insert(dialog_id.clone(), timer);
@@ -2965,24 +2979,30 @@ impl SipSession {
         &mut self,
         dialog_id: DialogId,
         response: &rsipstack::sip::Response,
-        default_expires: u64,
+        requested_session_interval: Duration,
     ) {
         let headers = &response.headers;
         let session_expires_value = get_header_value(headers, HEADER_SESSION_EXPIRES);
 
         let mut timer = SessionTimerState::default();
+        timer.mode = self.server.proxy_config.session_timer_mode();
         if let Some((session_interval, refresher)) = session_expires_value
             .as_deref()
             .and_then(parse_session_expires)
-            .map(|(interval, refresher)| (interval, refresher.unwrap_or(SessionRefresher::Uac)))
         {
             timer.enabled = true;
             timer.active = true;
             timer.last_refresh = Instant::now();
             timer.session_interval = session_interval;
-            timer.refresher = refresher;
+            timer.refresher = select_client_timer_refresher(refresher);
+        } else if timer.mode.is_always() {
+            timer.enabled = true;
+            timer.active = true;
+            timer.last_refresh = Instant::now();
+            timer.session_interval = requested_session_interval;
+            timer.refresher = SessionRefresher::Uac;
         } else {
-            timer.session_interval = Duration::from_secs(default_expires);
+            timer.session_interval = requested_session_interval;
         }
 
         self.timers.insert(dialog_id.clone(), timer);
@@ -3042,17 +3062,13 @@ impl SipSession {
     fn successful_refresh_response_headers(
         &self,
         dialog_id: &DialogId,
-        peer_supports_timer: bool,
     ) -> Option<Vec<rsipstack::sip::Header>> {
         let timer = self.timers.get(dialog_id)?;
         if !timer.enabled || !timer.active {
             return None;
         }
 
-        Some(build_session_timer_response_headers(
-            timer,
-            peer_supports_timer,
-        ))
+        Some(build_session_timer_response_headers(timer))
     }
 
     fn should_fallback_to_reinvite(status: StatusCode) -> bool {
@@ -3097,8 +3113,9 @@ impl SipSession {
         dialog_id: &DialogId,
         response: &rsipstack::sip::Response,
     ) -> Result<()> {
+        let we_are_uac = self.is_uac_dialog(dialog_id);
         if let Some(timer) = self.timers.get_mut(dialog_id) {
-            apply_refresh_response(timer, &response.headers)?;
+            apply_refresh_response(timer, &response.headers, we_are_uac)?;
         }
         Ok(())
     }
@@ -5157,7 +5174,11 @@ mod tests {
             body: Vec::new(),
         };
 
-        session.init_callee_timer(dialog_id.clone(), &response, DEFAULT_SESSION_EXPIRES);
+        session.init_callee_timer(
+            dialog_id.clone(),
+            &response,
+            Duration::from_secs(DEFAULT_SESSION_EXPIRES),
+        );
 
         let timer = session
             .timers


### PR DESCRIPTION
## Summary
- separate the basic `session_timer` switch from a new `session_timer_always` option
- align session timer negotiation and refresher selection with PJPROJECT behavior
- keep local refresh ownership in `always` mode when a successful refresh response omits `Session-Expires`

## Why
The previous implementation mixed negotiated and forced session-timer behavior behind one flag, which made it hard to match PJPROJECT semantics. It also had a caller-leg bug in `always` mode: when the peer replied to a refresh without `Session-Expires`, the code forced the refresher to `uac` unconditionally, which could flip ownership to the remote side on the inbound leg and stop further local refreshes.

## Impact
- `session_timer=true` keeps the normal negotiated behavior
- `session_timer_always=true` forces PJPROJECT-style always behavior without using `Require: timer`
- inbound and outbound legs now choose the refresher consistently with PJPROJECT
- the caller leg no longer stops refreshing after a header-less 200 OK in `always` mode

## Validation
- `cargo test test_session_timer_mode -- --nocapture`
- `cargo test session_timer -- --nocapture`
- `cargo test apply_refresh_response -- --nocapture`
- `cargo test test_init_callee_timer_disabled_without_session_expires -- --nocapture`
