### PR TITLE
Refine JsSIP ICE wait policy

### DIFF
--- a/static/phone_jssip.html
+++ b/static/phone_jssip.html
@@ -882,6 +882,26 @@
 
         const relayOnlyCheckbox = document.getElementById('relayOnly');
 
+        function escapeHtml(value) {
+            return String(value == null ? '' : value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function getIceServerUrls(server) {
+            if (!server || !server.urls) return [];
+            return Array.isArray(server.urls) ? server.urls : [server.urls];
+        }
+
+        function hasTurnIceServers(iceServers) {
+            return Array.isArray(iceServers) && iceServers.some((server) => {
+                return getIceServerUrls(server).some((url) => typeof url === 'string' && /^turns?:/i.test(url));
+            });
+        }
+
         function getEnabledPcConfigFromUi() {
             if (!iceEnable || !iceEnable.checked) return null;
             if (!iceServersInput) throw new Error('ICE servers input not found');
@@ -889,6 +909,51 @@
             const config = { iceServers };
             if (relayOnlyCheckbox && relayOnlyCheckbox.checked) config.iceTransportPolicy = 'relay';
             return config;
+        }
+
+        function getSessionPcConfig(session) {
+            if (session && session._icePcConfig) return session._icePcConfig;
+            try {
+                return getEnabledPcConfigFromUi();
+            } catch (error) {
+                return null;
+            }
+        }
+
+        function buildIceWaitPolicy(pcConfig) {
+            const iceServers = Array.isArray(pcConfig && pcConfig.iceServers) ? pcConfig.iceServers : [];
+            const relayOnly = Boolean(pcConfig && pcConfig.iceTransportPolicy === 'relay');
+            const hasTurn = hasTurnIceServers(iceServers);
+
+            if (relayOnly) {
+                return {
+                    kind: 'relay',
+                    description: 'waiting for relay candidate (relay-only mode)',
+                    allowPublicFallback: false
+                };
+            }
+
+            if (hasTurn) {
+                return {
+                    kind: 'relay',
+                    description: 'waiting for relay candidate (TURN configured)',
+                    allowPublicFallback: true
+                };
+            }
+
+            if (iceServers.length) {
+                return {
+                    kind: 'public',
+                    description: 'waiting for public candidate (srflx/relay)',
+                    allowPublicFallback: false
+                };
+            }
+
+            return {
+                kind: 'complete',
+                description: 'waiting for browser ICE completion',
+                allowPublicFallback: false
+            };
         }
 
         async function runIceDiagnostics() {
@@ -966,16 +1031,143 @@
             }
         }
 
-        const ICE_INACTIVITY_TIMEOUT = 2500;
+        const ICE_READY_SETTLE_MS = 250;
+        const ICE_READY_MAX_WAIT_MS = 2000;
         const WEBRTC_STATS_INTERVAL = 1000;
 
         function getIceTracker(session, label = 'session') {
             if (!session) return null;
             if (!session._iceTracker) {
-                session._iceTracker = { label, candidates: [], startedAt: null, endedAt: null, inactivityTimer: null, gatherDuration: null, status: 'waiting for candidates' };
+                session._iceTracker = {
+                    label,
+                    candidates: [],
+                    startedAt: null,
+                    endedAt: null,
+                    gatherDuration: null,
+                    status: 'waiting for candidates',
+                    readyCallback: null,
+                    readyTimer: null,
+                    maxWaitTimer: null,
+                    initialSdpSent: false,
+                    publicSeen: false,
+                    relaySeen: false,
+                    policy: null
+                };
             } else if (label && session._iceTracker.label !== label) session._iceTracker.label = label;
             session._iceCandidates = session._iceTracker.candidates;
+            refreshIceTrackerPolicy(session, session._iceTracker);
             return session._iceTracker;
+        }
+
+        function refreshIceTrackerPolicy(session, tracker) {
+            if (!tracker) return null;
+            const nextPolicy = buildIceWaitPolicy(getSessionPcConfig(session));
+            const previous = tracker.policy;
+            tracker.policy = nextPolicy;
+            if (!previous || previous.kind !== nextPolicy.kind || previous.description !== nextPolicy.description) {
+                if (!tracker.startedAt && !tracker.initialSdpSent) tracker.status = nextPolicy.description;
+            }
+            return nextPolicy;
+        }
+
+        function clearIceTrackerTimers(tracker) {
+            if (!tracker) return;
+            if (tracker.readyTimer) {
+                clearTimeout(tracker.readyTimer);
+                tracker.readyTimer = null;
+            }
+            if (tracker.maxWaitTimer) {
+                clearTimeout(tracker.maxWaitTimer);
+                tracker.maxWaitTimer = null;
+            }
+        }
+
+        function isPublicCandidateType(type) {
+            return type === 'relay' || type === 'srflx';
+        }
+
+        function describeIceWaitReason(tracker, source) {
+            const policy = tracker && tracker.policy ? tracker.policy : { kind: 'complete', allowPublicFallback: false };
+            if (source === 'settle') {
+                if (policy.kind === 'relay') return 'target relay candidate gathered';
+                if (policy.kind === 'public') return 'target public candidate gathered';
+            }
+
+            if (policy.kind === 'relay') {
+                if (tracker && tracker.relaySeen) return `${source}: relay candidate available`;
+                if (tracker && tracker.publicSeen && policy.allowPublicFallback) return `${source}: no relay candidate, falling back to public candidate`;
+                if (tracker && tracker.candidates.length) return `${source}: no relay/public candidate, sending gathered host candidates`;
+                return `${source}: no relay candidate gathered`;
+            }
+
+            if (policy.kind === 'public') {
+                if (tracker && tracker.publicSeen) return `${source}: public candidate available`;
+                if (tracker && tracker.candidates.length) return `${source}: no public candidate, sending gathered host candidates`;
+                return `${source}: no public candidate gathered`;
+            }
+
+            if (tracker && tracker.candidates.length) return `${source}: browser ICE completion not observed`;
+            return `${source}: no ICE candidate gathered`;
+        }
+
+        function startInitialSdpWait(session, tracker) {
+            if (!tracker) return;
+            const policy = refreshIceTrackerPolicy(session, tracker);
+            if (!tracker.startedAt) {
+                tracker.startedAt = Date.now();
+                tracker.status = policy ? policy.description : 'waiting for candidates';
+            }
+            if (!tracker.maxWaitTimer && !tracker.initialSdpSent && typeof tracker.readyCallback === 'function') {
+                tracker.maxWaitTimer = setTimeout(() => {
+                    tracker.maxWaitTimer = null;
+                    releaseInitialSdpWait(session, describeIceWaitReason(tracker, 'max wait reached'));
+                }, ICE_READY_MAX_WAIT_MS);
+            }
+            updateIceStatsDisplay(session);
+        }
+
+        function concludeIceWaitWithoutReady(session, reason) {
+            const tracker = session && session._iceTracker;
+            if (!tracker || tracker.initialSdpSent || tracker.endedAt) return;
+            tracker.endedAt = Date.now();
+            tracker.gatherDuration = tracker.startedAt ? (tracker.endedAt - tracker.startedAt) : null;
+            tracker.status = reason;
+            clearIceTrackerTimers(tracker);
+            updateIceStatsDisplay(session);
+        }
+
+        function releaseInitialSdpWait(session, reason) {
+            const tracker = session && session._iceTracker;
+            if (!tracker || tracker.initialSdpSent || typeof tracker.readyCallback !== 'function') return false;
+
+            clearIceTrackerTimers(tracker);
+            tracker.initialSdpSent = true;
+            tracker.endedAt = Date.now();
+            tracker.gatherDuration = tracker.startedAt ? (tracker.endedAt - tracker.startedAt) : null;
+            tracker.status = `sending SDP (${reason})`;
+            updateIceStatsDisplay(session);
+
+            try {
+                tracker.readyCallback();
+                return true;
+            } catch (error) {
+                tracker.initialSdpSent = false;
+                tracker.status = `ready() failed: ${error.message}`;
+                updateIceStatsDisplay(session);
+                return false;
+            }
+        }
+
+        function scheduleInitialSdpRelease(session, reason) {
+            const tracker = session && session._iceTracker;
+            if (!tracker || tracker.initialSdpSent || typeof tracker.readyCallback !== 'function') return;
+            if (tracker.readyTimer) return;
+            tracker.status = 'candidate matched, settling before SDP send';
+            updateIceStatsDisplay(session);
+            tracker.readyTimer = setTimeout(() => {
+                tracker.readyTimer = null;
+                releaseInitialSdpWait(session, reason);
+            }, ICE_READY_SETTLE_MS);
         }
 
         function updateIceStatsDisplay(session, statusText) {
@@ -1034,42 +1226,29 @@
             return out;
         }
 
-        function concludeIceGathering(session, reason) {
-            const tracker = session && session._iceTracker;
-            if (!tracker || tracker.endedAt) return;
-            tracker.endedAt = Date.now();
-            tracker.gatherDuration = tracker.startedAt ? (tracker.endedAt - tracker.startedAt) : null;
-            const readableReason = reason ? reason.replace(/_/g, ' ') : 'completed';
-            tracker.status = readableReason;
-            session._iceGatherDuration = tracker.gatherDuration;
-            log(`${tracker.label} - ICE gathering finished (${readableReason})${tracker.gatherDuration != null ? `, duration=${formatMs(tracker.gatherDuration)}` : ''}`);
-            if (tracker.inactivityTimer) { clearTimeout(tracker.inactivityTimer); tracker.inactivityTimer = null; }
-            updateIceStatsDisplay(session);
-        }
-
-        function scheduleIceInactivityTimeout(session) {
-            const tracker = session && session._iceTracker;
-            if (!tracker) return;
-            if (tracker.inactivityTimer) clearTimeout(tracker.inactivityTimer);
-            tracker.inactivityTimer = setTimeout(() => concludeIceGathering(session, 'inactivity timeout'), ICE_INACTIVITY_TIMEOUT);
-        }
-
-        function handleSessionIceCandidate(session, candidateObj) {
-            if (!session || !candidateObj) { concludeIceGathering(session, 'no candidate'); return; }
+        function handleSessionIceCandidate(session, candidateObj, readyCallback) {
+            if (!session || !candidateObj) return;
             const label = session._iceLabel || `${session.direction || 'session'}`;
             const tracker = getIceTracker(session, label);
+            if (typeof readyCallback === 'function') tracker.readyCallback = readyCallback;
             const candidateString = candidateObj.candidate || '';
-            if (!candidateString) { concludeIceGathering(session, 'null candidate'); return; }
+            if (!candidateString) return;
             const now = Date.now();
-            if (!tracker.startedAt) { tracker.startedAt = now; tracker.status = 'gathering'; log(`${tracker.label} - ICE gathering started`); }
+            if (!tracker.startedAt) startInitialSdpWait(session, tracker);
             const parsed = parseIceCandidate(candidateString, candidateObj);
             const entry = { ts: tracker.startedAt ? now - tracker.startedAt : 0, candidate: parsed.raw, type: parsed.type, address: parsed.address, port: parsed.port, relatedAddress: parsed.relatedAddress, relatedPort: parsed.relatedPort };
-            if (entry.candidate && tracker.candidates.some((c) => c.candidate === entry.candidate)) { scheduleIceInactivityTimeout(session); updateIceStatsDisplay(session, 'gathering'); return; }
+            if (entry.candidate && tracker.candidates.some((c) => c.candidate === entry.candidate)) { updateIceStatsDisplay(session); return; }
             tracker.candidates.push(entry);
-            const addrText = parsed.address ? `${parsed.address}${parsed.port ? `:${parsed.port}` : ''}` : 'address unavailable';
-            log(`${tracker.label} - candidate #${tracker.candidates.length}: ${parsed.type || 'unknown'} ${addrText} (+${formatMs(entry.ts)})`);
-            updateIceStatsDisplay(session, 'gathering');
-            scheduleIceInactivityTimeout(session);
+            if (parsed.type === 'relay') tracker.relaySeen = true;
+            if (isPublicCandidateType(parsed.type)) tracker.publicSeen = true;
+            if (tracker.policy && tracker.policy.kind === 'relay' && tracker.relaySeen) {
+                scheduleInitialSdpRelease(session, describeIceWaitReason(tracker, 'preferred candidate gathered'));
+            } else if (tracker.policy && tracker.policy.kind === 'public' && tracker.publicSeen) {
+                scheduleInitialSdpRelease(session, describeIceWaitReason(tracker, 'preferred candidate gathered'));
+            } else {
+                startInitialSdpWait(session, tracker);
+            }
+            updateIceStatsDisplay(session);
         }
 
         // ========== Registration ==========
@@ -1468,6 +1647,7 @@
             });
             session.on('ended', (data) => {
                 log(`Consult call ended: ${data.cause}`);
+                clearIceTrackerTimers(session._iceTracker);
                 consultSession = null;
                 isConsultOnHold = false;
                 updateCcControls();
@@ -1475,6 +1655,7 @@
             });
             session.on('failed', (data) => {
                 log(`Consult call failed: ${data.cause}`);
+                clearIceTrackerTimers(session._iceTracker);
                 consultSession = null;
                 isConsultOnHold = false;
                 updateCcControls();
@@ -1499,7 +1680,7 @@
                 } catch (e) {}
             }
             session.on('icecandidate', (event) => {
-                try { handleSessionIceCandidate(session, event ? event.candidate : null); } catch (error) {}
+                try { handleSessionIceCandidate(session, event ? event.candidate : null, event ? event.ready : null); } catch (error) {}
             });
         }
 
@@ -1572,7 +1753,7 @@
                 } catch (e) {}
             }
             session.on('icecandidate', (event) => {
-                try { handleSessionIceCandidate(session, event ? event.candidate : null); } catch (error) {}
+                try { handleSessionIceCandidate(session, event ? event.candidate : null, event ? event.ready : null); } catch (error) {}
             });
             session.on('sdp', (data) => {
                 logSipMessage(data.originator === 'local' ? 'SENT' : 'RECEIVED', 'SDP', data.sdp.substring(0, 300));
@@ -1590,6 +1771,8 @@
         }
 
         function endCall() {
+            clearIceTrackerTimers(currentSession && currentSession._iceTracker);
+            clearIceTrackerTimers(consultSession && consultSession._iceTracker);
             callControls.classList.remove('active');
             incomingCallDiv.classList.remove('active');
             callInfo.textContent = '';
@@ -1718,22 +1901,16 @@
             try {
                 if (!pc || session._iceMonitorAttached) return;
                 session._iceMonitorAttached = true;
+                try {
+                    if (typeof pc.getConfiguration === 'function') session._icePcConfig = pc.getConfiguration();
+                } catch (error) {}
                 const tracker = getIceTracker(session, label);
-                const statsLabel = tracker.label;
                 updateIceStatsDisplay(session, tracker.status);
                 pc.addEventListener('icegatheringstatechange', () => {
                     const state = pc.iceGatheringState;
-                    log(`${statsLabel} - iceGatheringState -> ${state}`);
-                    if (state === 'gathering' && !tracker.startedAt) { tracker.startedAt = Date.now(); tracker.status = 'gathering'; updateIceStatsDisplay(session); }
-                    if (state === 'complete' && tracker.startedAt && !tracker.endedAt) concludeIceGathering(session, 'ice gathering complete');
-                });
-                pc.addEventListener('iceconnectionstatechange', () => {
-                    const state = pc.iceConnectionState;
-                    log(`${statsLabel} - iceConnectionState -> ${state}`);
-                    if ((state === 'connected' || state === 'completed') && tracker.startedAt && !tracker.endedAt) concludeIceGathering(session, 'ice connection completed');
-                });
-                pc.addEventListener('connectionstatechange', () => {
-                    log(`${statsLabel} - connectionState -> ${pc.connectionState}`);
+                    if (state === 'gathering' && !tracker.startedAt && typeof tracker.readyCallback === 'function') startInitialSdpWait(session, tracker);
+                    if (state === 'complete') concludeIceWaitWithoutReady(session, describeIceWaitReason(tracker, 'browser ICE complete'));
+                    else updateIceStatsDisplay(session);
                 });
                 updateIceStatsDisplay(session, tracker.status);
             } catch (e) { log(`monitorIceGatheringJs error: ${e.message}`); }


### PR DESCRIPTION
## What changed

This updates `static/phone_jssip.html` to make the JsSIP ICE wait logic configuration-aware instead of relying on the first candidate or waiting indefinitely.

## Why it changed

The previous behavior could hang forever waiting for browser ICE completion, and earlier attempts to call `ready()` too early could send SDP with only early host candidates.

This change now:
- waits for `relay` when relay-only is enforced or TURN is configured
- waits for a public candidate (`srflx` or `relay`) when ICE is configured without TURN enforcement
- falls back to browser ICE completion when there is no useful ICE config
- uses a bounded max wait so the call setup does not stall forever
- clears ICE wait timers when sessions end

## Impact

WebRTC call setup is more predictable across STUN-only, TURN-available, and relay-only configurations, while avoiding the earlier one-way-audio risk from sending SDP too early.

## Root cause

JsSIP exposes `event.ready()` as an application-side decision point. Without a bounded strategy, the browser completion path could stall indefinitely; with an overly eager strategy, SDP could be sent before useful candidates were gathered.

## Validation

- Parsed the inline script in `static/phone_jssip.html` with `node`
- Verified call flows from logs for TURN-available and relay-only WebRTC-originated calls
