### PR TITLE
Fix IVR REFER hold cleanup

### DIFF
--- a/src/proxy/auth.rs
+++ b/src/proxy/auth.rs
@@ -5,11 +5,13 @@ use crate::call::{CalleeDisplayName, TransactionCookie, TrunkContext};
 use crate::config::ProxyConfig;
 use anyhow::{Error, Result};
 use async_trait::async_trait;
+use rsipstack::dialog::DialogId;
 use rsipstack::dialog::authenticate::verify_digest;
 use rsipstack::sip::Header;
 use rsipstack::sip::headers::{ProxyAuthenticate, WwwAuthenticate};
 use rsipstack::sip::prelude::HeadersExt;
 use rsipstack::sip::typed::Authorization;
+use rsipstack::transaction::key::TransactionRole;
 use rsipstack::transaction::transaction::Transaction;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -208,6 +210,15 @@ impl ProxyModule for AuthModule {
         if tx.original.method != rsipstack::sip::Method::Invite
             && tx.original.method != rsipstack::sip::Method::Register
         {
+            return Ok(ProxyAction::Continue);
+        }
+
+        if tx.original.method == rsipstack::sip::Method::Invite
+            && let Ok(dialog_id) =
+                DialogId::try_from((&tx.original, TransactionRole::Server))
+            && !dialog_id.local_tag.is_empty()
+        {
+            debug!(%dialog_id, "Bypassing authentication for in-dialog re-INVITE");
             return Ok(ProxyAction::Continue);
         }
 

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -963,6 +963,16 @@ impl SipSession {
                         for tx in subscribers.iter() {
                             let _ = tx.send(event.clone());
                         }
+                        if (200..300).contains(&sip_status) {
+                            self.hangup_reason
+                                .get_or_insert(CallRecordHangupReason::ByRefer);
+                            self.pending_hangup.insert(self.server_dialog.id());
+                            info!(
+                                session_id = %self.context.session_id,
+                                sip_status = %sip_status,
+                                "REFER completed successfully, hanging up original dialog"
+                            );
+                        }
                     }
                 }
             }
@@ -2910,6 +2920,15 @@ impl SipSession {
         changed_leg_sdp: &str,
     ) -> Result<()> {
         if self.media_profile.path != MediaPathMode::Anchored || self.media_bridge.is_some() {
+            return Ok(());
+        }
+
+        let has_remote_callee = self.connected_callee.is_some() || !self.callee_dialogs.is_empty();
+        if side == DialogSide::Caller && !has_remote_callee {
+            debug!(
+                session_id = %self.context.session_id,
+                "Skipping callee forwarding update for app-only caller dialog"
+            );
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary
- bypass auth challenges for in-dialog re-INVITE requests
- complete successful blind REFER by hanging up the original IVR dialog after final 2xx NOTIFY
- allow caller-side hold re-INVITE in app-only IVR sessions without requiring callee forwarding tracks

## Validation
- cargo check
