### PR TITLE
Fix database locator migration skipping

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -394,6 +394,7 @@ impl AppStateBuilder {
                     .with_sipflow_config(config.sipflow.clone())
                     .with_sipflow_backend(sipflow_backend_arc.clone())
                     .with_no_bind(self.skip_sip_bind)
+                    .with_skip_migrate(self.skip_migrate)
                     .with_addon_registry(Some(addon_registry.clone()))
                     .register_module("acl", AclModule::create)
                     .register_module("auth", AuthModule::create)

--- a/src/proxy/locator.rs
+++ b/src/proxy/locator.rs
@@ -470,12 +470,19 @@ pub(crate) fn sort_locations_by_recency(mut locations: Vec<Location>) -> Vec<Loc
 }
 
 pub async fn create_locator(config: &LocatorConfig) -> Result<Box<dyn Locator>> {
+    create_locator_with_migrate(config, true).await
+}
+
+pub async fn create_locator_with_migrate(
+    config: &LocatorConfig,
+    migrate: bool,
+) -> Result<Box<dyn Locator>> {
     match config {
         LocatorConfig::Memory | LocatorConfig::Http { .. } => {
             Ok(Box::new(MemoryLocator::new()) as Box<dyn Locator>)
         }
         LocatorConfig::Database { url } => {
-            let db_locator = DbLocator::new(url.clone()).await?;
+            let db_locator = DbLocator::new_with_migrate(url.clone(), migrate).await?;
             Ok(Box::new(db_locator) as Box<dyn Locator>)
         }
     }

--- a/src/proxy/locator_db.rs
+++ b/src/proxy/locator_db.rs
@@ -61,8 +61,8 @@ impl MigrationTrait for Migration {
                     .col(string(Column::Destination).char_len(255).not_null())
                     .col(string(Column::Transport).char_len(32).not_null())
                     .col(integer(Column::LastModified).not_null())
-                    .col(timestamp(Column::CreatedAt).not_null())
-                    .col(timestamp(Column::UpdatedAt).not_null())
+                    .col(timestamp(Column::CreatedAt).default(Expr::current_timestamp()))
+                    .col(timestamp(Column::UpdatedAt).default(Expr::current_timestamp()))
                     .col(boolean(Column::SupportsWebrtc).not_null().default(false))
                     .col(string_null(Column::UserAgent).char_len(255))
                     .to_owned(),
@@ -70,16 +70,23 @@ impl MigrationTrait for Migration {
             .await?;
 
         // Add index on username+realm
-        manager
-            .create_index(
-                Index::create()
-                    .table(Entity)
-                    .name("idx_locations_realm_username")
-                    .col(Column::Realm)
-                    .col(Column::Username)
-                    .to_owned(),
-            )
-            .await
+        if !manager
+            .has_index("rustpbx_locations", "idx_locations_realm_username")
+            .await?
+        {
+            manager
+                .create_index(
+                    Index::create()
+                        .table(Entity)
+                        .name("idx_locations_realm_username")
+                        .col(Column::Realm)
+                        .col(Column::Username)
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -110,6 +117,10 @@ impl MigratorTrait for Migrator {
 impl DbLocator {
     /// Create a new DbLocator with a database connection
     pub async fn new(url: String) -> Result<Self> {
+        Self::new_with_migrate(url, true).await
+    }
+
+    pub async fn new_with_migrate(url: String, migrate: bool) -> Result<Self> {
         // Connect to the database
         let db = Database::connect(&url)
             .await
@@ -119,17 +130,23 @@ impl DbLocator {
             realm_checker: Mutex::new(None),
         };
         info!("Creating DbLocator");
-        match db_locator.migrate().await {
-            Ok(_) => Ok(db_locator),
-            Err(e) => {
-                warn!("migrate locator fail {}", e);
-                Err(e)
+        if migrate {
+            match db_locator.migrate().await {
+                Ok(_) => Ok(db_locator),
+                Err(e) => {
+                    warn!("migrate locator fail {}", e);
+                    Err(e)
+                }
             }
+        } else {
+            Ok(db_locator)
         }
     }
 
     pub async fn migrate(&self) -> Result<()> {
-        Migrator::up(&self.db, None)
+        let manager = SchemaManager::new(&self.db);
+        Migration
+            .up(&manager)
             .await
             .map_err(|e| anyhow::anyhow!("Migration error: {}", e))?;
         Ok(())

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1,7 +1,7 @@
 use super::{
     FnCreateProxyModule, ProxyAction, ProxyModule,
     data::ProxyDataContext,
-    locator::{Locator, create_locator},
+    locator::{Locator, create_locator_with_migrate},
     user::{UserBackend, build_user_backend},
 };
 use crate::{
@@ -119,6 +119,7 @@ pub struct SipServerBuilder {
     /// Pre-built SipFlow backend (takes precedence over sipflow_config).
     sipflow_backend: Option<Arc<dyn SipFlowBackend>>,
     no_bind: bool,
+    skip_migrate: bool,
     /// Addon registry for accessing call applications (voicemail, ivr, etc.)
     addon_registry: Option<Arc<crate::addons::registry::AddonRegistry>>,
     /// RWI gateway to wire into the server for call-app factory use.
@@ -152,6 +153,7 @@ impl SipServerBuilder {
             sipflow_config: None,
             sipflow_backend: None,
             no_bind: false,
+            skip_migrate: false,
             addon_registry: None,
             rwi_gateway: None,
             agent_registry: None,
@@ -173,6 +175,11 @@ impl SipServerBuilder {
 
     pub fn with_no_bind(mut self, no_bind: bool) -> Self {
         self.no_bind = no_bind;
+        self
+    }
+
+    pub fn with_skip_migrate(mut self, skip_migrate: bool) -> Self {
+        self.skip_migrate = skip_migrate;
         self
     }
 
@@ -315,7 +322,7 @@ impl SipServerBuilder {
         let locator = if let Some(locator) = self.locator {
             locator
         } else {
-            match create_locator(&self.config.locator).await {
+            match create_locator_with_migrate(&self.config.locator, !self.skip_migrate).await {
                 Ok(locator) => locator,
                 Err(e) => {
                     warn!("failed to create locator: {} {:?}", e, self.config.locator);


### PR DESCRIPTION
## Summary

- Thread `skip_migrate` into SIP server locator construction so database locator startup respects `--skip-migrate`.
- Run the database locator table migration directly instead of through SeaORM's shared migration history table.
- Make locator index creation idempotent and align locator timestamps with existing MySQL-compatible schema defaults.

## Root Cause

The DB locator had its own migration path, but startup only skipped core and addon migrations. When migrations were not skipped, the locator migrator reused SeaORM's global migration history and failed after core migrations had inserted unrelated migration versions. On MySQL 5.7, the locator timestamp columns also needed explicit `CURRENT_TIMESTAMP` defaults.

## Validation

- `cargo check`
- `cargo check --features contact-center` attempted on a clean `upstream/main` worktree; it fails before this change because the branch is missing feature-gated addon modules (`cc`, `endpoint_manager`, `enterprise_auth`, `voicemail`, `ivr_editor`, `telemetry`).
- Local runtime validation against MySQL 5.7: fresh schema migration, schema-only dump/import, and `--skip-migrate` startup with DB locator registrations and lookups working.
