### PR TITLE
Remove extension pending reload banner

### DIFF
--- a/src/console/handlers/extension.rs
+++ b/src/console/handlers/extension.rs
@@ -487,7 +487,6 @@ async fn create_extension(
                 .into_response();
         }
 
-    state.mark_pending_reload();
     Json(json!({"status": "ok", "id": model.id})).into_response()
 }
 
@@ -746,7 +745,6 @@ async fn update_extension(
             )
                 .into_response();
         }
-    state.mark_pending_reload();
     Json(json!({"status": "ok"})).into_response()
 }
 
@@ -763,10 +761,7 @@ async fn delete_extension(
             .into_response();
     }
     match ExtensionEntity::delete_by_id(id).exec(state.db()).await {
-        Ok(r) => {
-            state.mark_pending_reload();
-            Json(json!({"status": r.rows_affected})).into_response()
-        }
+        Ok(r) => Json(json!({"status": r.rows_affected})).into_response(),
         Err(err) => {
             warn!("failed to delete extension {}: {}", id, err);
             (


### PR DESCRIPTION
## Summary
- stop marking the global pending-reload banner after extension create, update, and delete

## Why
Extension changes are DB-backed and should not imply a RustPBX backend reload is required.

## Validation
- cargo check