### PR TITLE
Bind RTP sockets to proxy address

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -524,6 +524,7 @@ impl SessionTimerMode {
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct RtpConfig {
     pub external_ip: Option<String>,
+    pub bind_ip: Option<String>,
     pub start_port: Option<u16>,
     pub end_port: Option<u16>,
     pub webrtc_start_port: Option<u16>,
@@ -978,6 +979,7 @@ impl Config {
     pub fn rtp_config(&self) -> RtpConfig {
         RtpConfig {
             external_ip: self.external_ip.clone(),
+            bind_ip: Some(self.proxy.addr.clone()),
             start_port: self.rtp_start_port,
             end_port: self.rtp_end_port,
             webrtc_start_port: self.webrtc_port_start,
@@ -1084,5 +1086,17 @@ mod tests {
 
         config.session_timer = false;
         assert_eq!(config.session_timer_mode(), SessionTimerMode::Off);
+    }
+
+    #[test]
+    fn test_rtp_config_uses_proxy_addr_for_bind_ip() {
+        let mut config = Config::default();
+        config.proxy.addr = "120.228.209.243".to_string();
+        config.external_ip = Some("203.0.113.10".to_string());
+
+        let rtp_config = config.rtp_config();
+
+        assert_eq!(rtp_config.bind_ip.as_deref(), Some("120.228.209.243"));
+        assert_eq!(rtp_config.external_ip.as_deref(), Some("203.0.113.10"));
     }
 }

--- a/src/media/bridge.rs
+++ b/src/media/bridge.rs
@@ -906,6 +906,7 @@ pub struct BridgePeerBuilder {
     rtp_port_range: (u16, u16),
     enable_latching: bool,
     external_ip: Option<String>,
+    bind_ip: Option<String>,
     webrtc_audio_capabilities: Option<Vec<rustrtc::config::AudioCapability>>,
     rtp_audio_capabilities: Option<Vec<rustrtc::config::AudioCapability>>,
     webrtc_video_capabilities: Option<Vec<rustrtc::config::VideoCapability>>,
@@ -926,6 +927,7 @@ impl BridgePeerBuilder {
             rtp_port_range: (20000, 30000),
             enable_latching: false,
             external_ip: None,
+            bind_ip: None,
             webrtc_audio_capabilities: None,
             rtp_audio_capabilities: None,
             webrtc_video_capabilities: None,
@@ -960,6 +962,11 @@ impl BridgePeerBuilder {
 
     pub fn with_external_ip(mut self, ip: String) -> Self {
         self.external_ip = Some(ip);
+        self
+    }
+
+    pub fn with_bind_ip(mut self, ip: String) -> Self {
+        self.bind_ip = Some(ip);
         self
     }
 
@@ -1078,6 +1085,7 @@ impl BridgePeerBuilder {
                 rtp_end_port: Some(self.rtp_port_range.1),
                 enable_latching: self.enable_latching,
                 external_ip: self.external_ip,
+                bind_ip: self.bind_ip,
                 media_capabilities: rtp_media_caps,
                 ssrc_start: rand::random::<u32>(),
                 sdp_compatibility: self.rtp_sdp_compatibility,

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -469,6 +469,7 @@ pub struct RtpTrackBuilder {
     track_id: String,
     cancel_token: Option<CancellationToken>,
     external_ip: Option<String>,
+    bind_ip: Option<String>,
     rtp_start_port: Option<u16>,
     rtp_end_port: Option<u16>,
     mode: TransportMode,
@@ -484,6 +485,7 @@ impl RtpTrackBuilder {
             track_id,
             cancel_token: None,
             external_ip: None,
+            bind_ip: None,
             rtp_start_port: None,
             rtp_end_port: None,
             mode: TransportMode::Rtp,
@@ -527,6 +529,11 @@ impl RtpTrackBuilder {
 
     pub fn with_external_ip(mut self, addr: String) -> Self {
         self.external_ip = Some(addr);
+        self
+    }
+
+    pub fn with_bind_ip(mut self, addr: String) -> Self {
+        self.bind_ip = Some(addr);
         self
     }
 
@@ -600,6 +607,12 @@ impl RtpTrackBuilder {
         })
         .collect();
 
+        let bind_ip = if matches!(self.mode, TransportMode::Rtp | TransportMode::Srtp) {
+            self.bind_ip
+        } else {
+            None
+        };
+
         let config = RtcConfiguration {
             ice_servers: self.ice_servers,
             ice_transport_policy: if self.mode == TransportMode::WebRtc && has_turn_server {
@@ -611,6 +624,7 @@ impl RtpTrackBuilder {
             rtp_start_port: self.rtp_start_port,
             rtp_end_port: self.rtp_end_port,
             external_ip: self.external_ip,
+            bind_ip,
             enable_latching: self.enable_latching,
             media_capabilities: Some(rustrtc::config::MediaCapabilities {
                 audio: audio_capabilities,
@@ -646,6 +660,7 @@ pub struct FileTrack {
     rtp_start_port: Option<u16>,
     rtp_end_port: Option<u16>,
     external_ip: Option<String>,
+    bind_ip: Option<String>,
     audio_source_manager: Option<Arc<audio_source::AudioSourceManager>>,
     muted: std::sync::atomic::AtomicBool,
 }
@@ -665,6 +680,7 @@ impl Clone for FileTrack {
             rtp_start_port: self.rtp_start_port,
             rtp_end_port: self.rtp_end_port,
             external_ip: self.external_ip.clone(),
+            bind_ip: self.bind_ip.clone(),
             audio_source_manager: self.audio_source_manager.clone(),
             muted: std::sync::atomic::AtomicBool::new(
                 self.muted.load(std::sync::atomic::Ordering::Relaxed),
@@ -696,6 +712,7 @@ impl FileTrack {
             rtp_start_port: None,
             rtp_end_port: None,
             external_ip: None,
+            bind_ip: None,
             audio_source_manager: None,
             muted: std::sync::atomic::AtomicBool::new(false),
         }
@@ -745,12 +762,25 @@ impl FileTrack {
         self
     }
 
+    pub fn with_bind_ip(mut self, ip: String) -> Self {
+        self.bind_ip = Some(ip);
+        self.recreate_pc();
+        self
+    }
+
     fn recreate_pc(&mut self) {
+        let bind_ip = if matches!(self.mode, TransportMode::Rtp | TransportMode::Srtp) {
+            self.bind_ip.clone()
+        } else {
+            None
+        };
+
         let config = RtcConfiguration {
             transport_mode: self.mode.clone(),
             rtp_start_port: self.rtp_start_port,
             rtp_end_port: self.rtp_end_port,
             external_ip: self.external_ip.clone(),
+            bind_ip,
             ssrc_start: rand::random::<u32>(),
             ..Default::default()
         };

--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -1602,8 +1602,13 @@ impl CallModule {
         let media_track =
             crate::media::RtpTrackBuilder::new(format!("inbound-refer-{}", new_call_id))
                 .with_cancel_token(tokio_util::sync::CancellationToken::new())
-                .with_external_ip(external_ip)
-                .build();
+                .with_external_ip(external_ip);
+        let media_track = if let Some(bind_ip) = server.rtp_config.bind_ip.clone() {
+            media_track.with_bind_ip(bind_ip)
+        } else {
+            media_track
+        }
+        .build();
 
         let sdp_offer = media_track
             .local_description()

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -2207,6 +2207,9 @@ impl SipSession {
                 if let Some(ref external_ip) = self.server.rtp_config.external_ip {
                     track_builder = track_builder.with_external_ip(external_ip.clone());
                 }
+                if let Some(ref bind_ip) = self.server.rtp_config.bind_ip {
+                    track_builder = track_builder.with_bind_ip(bind_ip.clone());
+                }
 
                 let (start_port, end_port) = if caller_is_webrtc {
                     (
@@ -2697,6 +2700,9 @@ impl SipSession {
             if let Some(ref external_ip) = self.server.rtp_config.external_ip {
                 bridge_builder = bridge_builder.with_external_ip(external_ip.clone());
             }
+            if let Some(ref bind_ip) = self.server.rtp_config.bind_ip {
+                bridge_builder = bridge_builder.with_bind_ip(bind_ip.clone());
+            }
 
             if let Some(ref ice_servers) = self.context.dialplan.media.ice_servers {
                 bridge_builder = bridge_builder.with_ice_servers(ice_servers.clone());
@@ -2872,6 +2878,9 @@ impl SipSession {
             if let Some(ref external_ip) = self.server.rtp_config.external_ip {
                 track_builder = track_builder.with_external_ip(external_ip.clone());
             }
+            if let Some(ref bind_ip) = self.server.rtp_config.bind_ip {
+                track_builder = track_builder.with_bind_ip(bind_ip.clone());
+            }
 
             let (start_port, end_port) = if callee_is_webrtc {
                 (
@@ -2966,6 +2975,9 @@ impl SipSession {
 
         if let Some(ref external_ip) = self.server.rtp_config.external_ip {
             track_builder = track_builder.with_external_ip(external_ip.clone());
+        }
+        if let Some(ref bind_ip) = self.server.rtp_config.bind_ip {
+            track_builder = track_builder.with_bind_ip(bind_ip.clone());
         }
 
         let (start_port, end_port) = if caller_is_webrtc {

--- a/src/rwi/processor.rs
+++ b/src/rwi/processor.rs
@@ -871,8 +871,13 @@ impl RwiCommandProcessor {
         let media_track =
             crate::media::RtpTrackBuilder::new(format!("rwi-originate-{}", req.call_id))
                 .with_cancel_token(tokio_util::sync::CancellationToken::new())
-                .with_external_ip(external_ip.clone())
-                .build();
+                .with_external_ip(external_ip.clone());
+        let media_track = if let Some(bind_ip) = server.rtp_config.bind_ip.clone() {
+            media_track.with_bind_ip(bind_ip)
+        } else {
+            media_track
+        }
+        .build();
 
         tracing::info!(call_id = %req.call_id, external_ip = %external_ip, "Created media track for originate");
 
@@ -1459,8 +1464,13 @@ impl RwiCommandProcessor {
         let media_track =
             crate::media::RtpTrackBuilder::new(format!("parallel-{}-{}", operation_id, call_id))
                 .with_cancel_token(tokio_util::sync::CancellationToken::new())
-                .with_external_ip(external_ip.clone())
-                .build();
+                .with_external_ip(external_ip.clone());
+        let media_track = if let Some(bind_ip) = server.rtp_config.bind_ip.clone() {
+            media_track.with_bind_ip(bind_ip)
+        } else {
+            media_track
+        }
+        .build();
 
         let sdp_offer = match media_track.local_description().await {
             Ok(sdp) => {

--- a/src/rwi/transfer.rs
+++ b/src/rwi/transfer.rs
@@ -994,8 +994,13 @@ impl TransferController {
         // Create media track and SDP offer
         let media_track = crate::media::RtpTrackBuilder::new(format!("3pcc-{}", call_id))
             .with_cancel_token(tokio_util::sync::CancellationToken::new())
-            .with_external_ip(external_ip)
-            .build();
+            .with_external_ip(external_ip);
+        let media_track = if let Some(bind_ip) = sip_server.rtp_config.bind_ip.clone() {
+            media_track.with_bind_ip(bind_ip)
+        } else {
+            media_track
+        }
+        .build();
 
         let sdp_offer = media_track
             .local_description()


### PR DESCRIPTION
## Summary
- reuse the configured SIP proxy address as the RTP bind address
- pass the bind address into RTP/SRTP media track and bridge builders
- keep external_ip as an advertise override instead of using it for Docker bind behavior

## Verification
- cargo check
- cargo test test_rtp_config_uses_proxy_addr_for_bind_ip
- git diff --cached --check