### PR TITLE
Fix clustered SIP target routing

### DIFF
--- a/src/proxy/locator.rs
+++ b/src/proxy/locator.rs
@@ -68,12 +68,22 @@ pub trait Locator: Send + Sync {
 
 pub struct DialogTargetLocator {
     locator: Arc<Box<dyn Locator>>,
+    local_addrs: Vec<SipAddr>,
 }
 
 impl DialogTargetLocator {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(locator: Arc<Box<dyn Locator>>) -> Box<dyn TargetLocator> {
-        Box::new(Self { locator }) as Box<dyn TargetLocator>
+    pub fn new(locator: Arc<Box<dyn Locator>>, local_addrs: Vec<SipAddr>) -> Box<dyn TargetLocator> {
+        Box::new(Self {
+            locator,
+            local_addrs,
+        }) as Box<dyn TargetLocator>
+    }
+
+    fn is_local_home_proxy(&self, home_proxy: &SipAddr) -> bool {
+        self.local_addrs
+            .iter()
+            .any(|addr| addr.addr.to_string() == home_proxy.addr.to_string())
     }
 }
 
@@ -81,11 +91,24 @@ impl DialogTargetLocator {
 impl TargetLocator for DialogTargetLocator {
     async fn locate(&self, uri: &rsipstack::sip::Uri) -> Result<SipAddr, rsipstack::Error> {
         if let Ok(locs) = self.locator.lookup(uri).await
-            && let Some(loc) = locs.first()
-                && let Some(dest) = &loc.destination {
+            && let Some(loc) = locs.first() {
+                if loc.registered_aor.as_ref() == Some(uri)
+                    && let Some(home_proxy) = &loc.home_proxy {
+                        if self.is_local_home_proxy(home_proxy)
+                            && let Some(dest) = &loc.destination {
+                                debug!(%uri, %dest, %home_proxy, "Located local registered AOR target via destination");
+                                return Ok(dest.clone());
+                            }
+
+                        debug!(%uri, dest = %home_proxy, "Located registered AOR target via home proxy");
+                        return Ok(home_proxy.clone());
+                    }
+
+                if let Some(dest) = &loc.destination {
                     debug!(%uri, %dest, "Located target for dialog");
                     return Ok(dest.clone());
                 }
+            }
         SipAddr::try_from(uri).map_err(|e| {
             rsipstack::Error::Error(format!(
                 "failed to convert uri to sip addr: {}, error: {}",
@@ -684,7 +707,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dialog_target_locator_uses_destination() {
+    async fn dialog_target_locator_routes_registered_aor_via_home_proxy() {
         let locator = MemoryLocator::new();
         let uri: rsipstack::sip::Uri = "sip:alice@rustpbx.com".try_into().unwrap();
 
@@ -707,6 +730,7 @@ mod tests {
                     expires: 3600,
                     destination: Some(destination.clone()),
                     home_proxy: Some(home_proxy.clone()),
+                    registered_aor: Some(uri.clone()),
                     last_modified: Some(Instant::now()),
                     ..Default::default()
                 },
@@ -714,9 +738,93 @@ mod tests {
             .await
             .unwrap();
 
-        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)));
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![]);
         let result = target_locator.locate(&uri).await.unwrap();
-        assert_eq!(result, destination, "DialogTargetLocator should use destination");
+        assert_eq!(
+            result, home_proxy,
+            "DialogTargetLocator should route registered AOR via home_proxy"
+        );
+    }
+
+    #[tokio::test]
+    async fn dialog_target_locator_routes_local_registered_aor_to_destination() {
+        let locator = MemoryLocator::new();
+        let uri: rsipstack::sip::Uri = "sip:alice@pbx.rustpbx.com".try_into().unwrap();
+
+        let destination = SipAddr {
+            r#type: Some(Transport::Ws),
+            addr: HostWithPort::try_from("127.0.0.1:63255").unwrap(),
+        };
+
+        let home_proxy = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: HostWithPort::try_from("10.0.0.1:5060").unwrap(),
+        };
+
+        locator
+            .register(
+                "alice",
+                Some("pbx.rustpbx.com"),
+                Location {
+                    aor: "sip:abc@invalid.invalid;transport=ws".try_into().unwrap(),
+                    expires: 3600,
+                    destination: Some(destination.clone()),
+                    home_proxy: Some(home_proxy.clone()),
+                    registered_aor: Some(uri.clone()),
+                    last_modified: Some(Instant::now()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![home_proxy]);
+        let result = target_locator.locate(&uri).await.unwrap();
+        assert_eq!(
+            result, destination,
+            "local registered AOR should be delivered to the stored device/WS destination"
+        );
+    }
+
+    #[tokio::test]
+    async fn dialog_target_locator_keeps_contact_destination_for_non_registered_aor() {
+        let locator = MemoryLocator::new();
+        let uri: rsipstack::sip::Uri = "sip:alice@rustpbx.com".try_into().unwrap();
+        let registered_aor: rsipstack::sip::Uri = "sip:alice@pbx.rustpbx.com".try_into().unwrap();
+
+        let destination = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: HostWithPort::try_from("192.168.1.10:5060").unwrap(),
+        };
+
+        let home_proxy = SipAddr {
+            r#type: Some(Transport::Tcp),
+            addr: HostWithPort::try_from("10.0.0.1:5060").unwrap(),
+        };
+
+        locator
+            .register(
+                "alice",
+                Some("rustpbx.com"),
+                Location {
+                    aor: uri.clone(),
+                    expires: 3600,
+                    destination: Some(destination.clone()),
+                    home_proxy: Some(home_proxy),
+                    registered_aor: Some(registered_aor),
+                    last_modified: Some(Instant::now()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![]);
+        let result = target_locator.locate(&uri).await.unwrap();
+        assert_eq!(
+            result, destination,
+            "DialogTargetLocator should keep contact destination when URI is not registered AOR"
+        );
     }
 
     #[test]
@@ -783,7 +891,7 @@ mod tests {
             .await
             .unwrap();
 
-        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)));
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![]);
         let result = target_locator.locate(&uri).await.unwrap();
         assert_eq!(result, destination, "DialogTargetLocator should fallback to destination when home_proxy is absent");
     }

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -602,19 +602,12 @@ impl SipSession {
             .any(|addr| addr.addr.to_string() == home_proxy.addr.to_string())
     }
 
-    fn resolve_outbound_destination(
-        target: &Location,
-        local_addrs: &[SipAddr],
-    ) -> (Option<SipAddr>, bool) {
+    fn route_via_home_proxy(target: &Location, local_addrs: &[SipAddr]) -> bool {
         if let Some(home_proxy) = target.home_proxy.as_ref() {
-            if Self::is_local_home_proxy(local_addrs, home_proxy) {
-                (target.destination.clone(), false)
-            } else {
-                (Some(home_proxy.clone()), true)
-            }
-        } else {
-            (target.destination.clone(), false)
+            return !Self::is_local_home_proxy(local_addrs, home_proxy);
         }
+
+        false
     }
 
     fn resolve_outbound_callee_uri(
@@ -1732,8 +1725,7 @@ impl SipSession {
         })?;
 
         let local_addrs = self.server.endpoint.get_addrs();
-        let (destination, route_via_home_proxy) =
-            Self::resolve_outbound_destination(target, &local_addrs);
+        let route_via_home_proxy = Self::route_via_home_proxy(target, &local_addrs);
         let callee_uri = Self::resolve_outbound_callee_uri(target, route_via_home_proxy);
 
         let mut headers: Vec<rsipstack::sip::Header> =
@@ -1749,8 +1741,8 @@ impl SipSession {
         if route_via_home_proxy {
             debug!(
                 session_id = %self.context.session_id,
-                destination = ?destination,
-                "Routing via home_proxy without self-referencing Record-Route"
+                %callee_uri,
+                "Routing via home_proxy request URI without self-referencing Record-Route"
             );
         }
 
@@ -1819,7 +1811,7 @@ impl SipSession {
             }
         }
 
-        info!(session_id = %self.context.session_id, %caller, %callee_uri, callee_call_id, ?destination, "Sending INVITE to callee");
+        info!(session_id = %self.context.session_id, %caller, %callee_uri, callee_call_id, "Sending INVITE to callee");
 
         let mut invite_option = InviteOption {
             caller_display_name: self.context.dialplan.caller_display_name.clone(),
@@ -1827,7 +1819,7 @@ impl SipSession {
             caller: caller.clone(),
             content_type,
             offer,
-            destination,
+            destination: None,
             contact: contact_uri,
             credential: target.credential.clone(),
             headers: Some(headers),
@@ -7536,7 +7528,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_outbound_destination_prefers_remote_home_proxy() {
+    fn test_route_via_home_proxy_detects_remote_home_proxy() {
         let destination = SipAddr {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("192.168.1.10:5060").unwrap(),
@@ -7557,15 +7549,11 @@ mod tests {
             addr: rsipstack::sip::HostWithPort::try_from("10.0.0.1:5060").unwrap(),
         }];
 
-        let (resolved, via_home_proxy) =
-            SipSession::resolve_outbound_destination(&target, &local_addrs);
-
-        assert!(via_home_proxy);
-        assert_eq!(resolved, Some(home_proxy));
+        assert!(SipSession::route_via_home_proxy(&target, &local_addrs));
     }
 
     #[test]
-    fn test_resolve_outbound_destination_uses_destination_for_local_home_proxy() {
+    fn test_route_via_home_proxy_ignores_local_home_proxy() {
         let destination = SipAddr {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("192.168.1.10:5060").unwrap(),
@@ -7586,11 +7574,7 @@ mod tests {
             addr: rsipstack::sip::HostWithPort::try_from("10.0.0.1:5060").unwrap(),
         }];
 
-        let (resolved, via_home_proxy) =
-            SipSession::resolve_outbound_destination(&target, &local_addrs);
-
-        assert!(!via_home_proxy);
-        assert_eq!(resolved, Some(destination));
+        assert!(!SipSession::route_via_home_proxy(&target, &local_addrs));
     }
 
     #[test]
@@ -8316,10 +8300,10 @@ mod tests {
         assert!(SipSession::is_local_home_proxy(&local_addrs, &home_proxy));
     }
 
-    // ─── resolve_outbound_destination: route_via_home_proxy flag ───────
+    // ─── route_via_home_proxy flag ───────
 
     #[test]
-    fn test_resolve_outbound_destination_no_home_proxy_returns_destination() {
+    fn test_route_via_home_proxy_false_without_home_proxy() {
         let destination = SipAddr {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("192.168.1.10:5060").unwrap(),
@@ -8333,15 +8317,12 @@ mod tests {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.0.0.1:5060").unwrap(),
         }];
-        let (resolved, via_home_proxy) =
-            SipSession::resolve_outbound_destination(&target, &local_addrs);
-        assert!(!via_home_proxy);
-        assert_eq!(resolved, Some(destination));
+        assert!(!SipSession::route_via_home_proxy(&target, &local_addrs));
     }
 
     #[test]
-    fn test_resolve_outbound_destination_remote_home_proxy_sets_via_flag() {
-        // home_proxy != local → route_via_home_proxy stays true (FIXED behavior)
+    fn test_route_via_home_proxy_remote_home_proxy_sets_via_flag() {
+        // home_proxy != local -> route_via_home_proxy stays true.
         let destination = SipAddr {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.172.149.126:8060").unwrap(),
@@ -8359,17 +8340,15 @@ mod tests {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.172.148.121:8060").unwrap(),
         }];
-        let (resolved, via_home_proxy) =
-            SipSession::resolve_outbound_destination(&target, &local_addrs);
+        let via_home_proxy = SipSession::route_via_home_proxy(&target, &local_addrs);
         assert!(
             via_home_proxy,
             "route_via_home_proxy must be true for remote home_proxy"
         );
-        assert_eq!(resolved, Some(home_proxy));
     }
 
     #[test]
-    fn test_resolve_outbound_destination_local_home_proxy_no_via_flag() {
+    fn test_route_via_home_proxy_local_home_proxy_no_via_flag() {
         let destination = SipAddr {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.172.148.121:8060").unwrap(),
@@ -8387,13 +8366,11 @@ mod tests {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.172.148.121:8060").unwrap(),
         }];
-        let (resolved, via_home_proxy) =
-            SipSession::resolve_outbound_destination(&target, &local_addrs);
+        let via_home_proxy = SipSession::route_via_home_proxy(&target, &local_addrs);
         assert!(
             !via_home_proxy,
             "route_via_home_proxy must be false when home_proxy is local"
         );
-        assert_eq!(resolved, Some(destination));
     }
 
     // ─── Verify no self-referencing Record-Route in INVITE headers ────
@@ -8411,12 +8388,11 @@ mod tests {
         // The Contact header in the INVITE already provides the correct
         // return path for the callee's responses and requests.
         //
-        // This test exercises is_local_home_proxy and
-        // resolve_outbound_destination to ensure the routing logic is
-        // correct. The actual INVITE header construction is exercised
+        // This test exercises is_local_home_proxy and route_via_home_proxy
+        // to ensure the routing logic is correct. The actual INVITE header construction is exercised
         // by the cluster home_proxy e2e test.
         //
-        // Verify: home_proxy is recognized as remote → via_home_proxy=true
+        // Verify: home_proxy is recognized as remote -> via_home_proxy=true
         let destination = SipAddr {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.172.149.126:8060").unwrap(),
@@ -8434,8 +8410,7 @@ mod tests {
             r#type: Some(rsipstack::sip::Transport::Udp),
             addr: rsipstack::sip::HostWithPort::try_from("10.172.148.121:8060").unwrap(),
         }];
-        let (_resolved, via_home_proxy) =
-            SipSession::resolve_outbound_destination(&target, &local_addrs);
+        let via_home_proxy = SipSession::route_via_home_proxy(&target, &local_addrs);
         assert!(
             via_home_proxy,
             "route_via_home_proxy must be true for cross-node routing"

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -35,7 +35,7 @@ use rsipstack::{
         transaction::Transaction,
     },
     transport::{
-        TcpListenerConnection, TlsConfig, TlsListenerConnection, TransportLayer,
+        SipAddr, TcpListenerConnection, TlsConfig, TlsListenerConnection, TransportLayer,
         WebSocketListenerConnection, udp::UdpConnection,
     },
 };
@@ -551,8 +551,16 @@ impl SipServerBuilder {
             tx
         });
 
+        let locator_local_addrs = local_addrs
+            .iter()
+            .map(|addr| SipAddr {
+                r#type: None,
+                addr: (*addr).into(),
+            })
+            .collect();
+
         endpoint_builder = endpoint_builder
-            .with_target_locator(DialogTargetLocator::new(locator.clone()))
+            .with_target_locator(DialogTargetLocator::new(locator.clone(), locator_local_addrs))
             .with_transport_inspector(TransportInspectorLocator::new(
                 locator.clone(),
                 locator_events.clone(),


### PR DESCRIPTION
## Summary

- Route registered AoR targets through the owning home proxy only when that home proxy is remote.
- Deliver local registered AoR targets through the stored locator destination, preserving WebSocket delivery for WebRTC clients.
- Stop pre-setting `InviteOption.destination` for locator-backed INVITEs so follow-up requests use the same target locator path.

## Validation

- `cargo test dialog_target_locator --lib`
- `cargo check`

## Scope

- Source-only PR: `src/proxy/locator.rs`, `src/proxy/proxy_call/sip_session.rs`, `src/proxy/server.rs`.
