### PR TITLE
Fix bridge-backed queue media playback

### DIFF
--- a/src/media/bridge.rs
+++ b/src/media/bridge.rs
@@ -55,7 +55,7 @@ use rustrtc::{
 };
 use std::sync::{
     Arc,
-    atomic::{AtomicU8, AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
 };
 use tokio::sync::Mutex as AsyncMutex;
 use tokio_util::sync::CancellationToken;
@@ -118,6 +118,13 @@ impl LegTransport {
             Self::Rtp => "RTP",
         }
     }
+
+    const fn endpoint(self) -> BridgeEndpoint {
+        match self {
+            Self::WebRtc => BridgeEndpoint::WebRtc,
+            Self::Rtp => BridgeEndpoint::Rtp,
+        }
+    }
 }
 
 /// Typed metadata describing source and destination leg transports.
@@ -132,6 +139,10 @@ impl ForwardPath {
         Self { from, to }
     }
 
+    const fn source_endpoint(self) -> BridgeEndpoint {
+        self.from.endpoint()
+    }
+
     /// Strip WebRTC-only fields when forwarding into a plain RTP pipeline.
     const fn should_strip_webrtc_audio_metadata(self) -> bool {
         matches!(
@@ -144,6 +155,55 @@ impl ForwardPath {
 impl std::fmt::Display for ForwardPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}→{}", self.from.as_str(), self.to.as_str())
+    }
+}
+
+type DtmfHandler = Arc<dyn Fn(char) + Send + Sync + 'static>;
+
+#[derive(Clone)]
+struct BridgeDtmfSink {
+    endpoint: BridgeEndpoint,
+    payload_type: u8,
+    handler: DtmfHandler,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BridgeDtmfEventKey {
+    digit_code: u8,
+    rtp_timestamp: u32,
+}
+
+#[derive(Debug, Default)]
+struct BridgeDtmfDetector {
+    last_event: Option<BridgeDtmfEventKey>,
+}
+
+impl BridgeDtmfDetector {
+    fn observe(&mut self, payload: &[u8], rtp_timestamp: u32) -> Option<char> {
+        if payload.len() < 4 {
+            return None;
+        }
+
+        let digit_code = payload[0];
+        let digit = match digit_code {
+            0..=9 => (b'0' + digit_code) as char,
+            10 => '*',
+            11 => '#',
+            12..=15 => (b'A' + (digit_code - 12)) as char,
+            _ => return None,
+        };
+
+        let event = BridgeDtmfEventKey {
+            digit_code,
+            rtp_timestamp,
+        };
+
+        if self.last_event == Some(event) {
+            return None;
+        }
+
+        self.last_event = Some(event);
+        Some(digit)
     }
 }
 
@@ -239,8 +299,10 @@ pub struct BridgePeer {
     bridge_tasks: AsyncMutex<Vec<tokio::task::JoinHandle<()>>>,
     /// Cancellation token
     cancel_token: CancellationToken,
+    forwarding_started: AtomicBool,
     /// Shared recorder for call recording (written by both bridge directions)
     recorder: Option<Arc<parking_lot::RwLock<Option<Recorder>>>>,
+    dtmf_sink: Arc<parking_lot::RwLock<Option<BridgeDtmfSink>>>,
     /// Audio sender channels for forwarding
     webrtc_send: Arc<AsyncMutex<Option<MediaSender>>>,
     rtp_send: Arc<AsyncMutex<Option<MediaSender>>>,
@@ -277,7 +339,9 @@ impl BridgePeer {
             rtp_pc,
             bridge_tasks: AsyncMutex::new(Vec::new()),
             cancel_token: CancellationToken::new(),
+            forwarding_started: AtomicBool::new(false),
             recorder: None,
+            dtmf_sink: Arc::new(parking_lot::RwLock::new(None)),
             webrtc_send: Arc::new(AsyncMutex::new(None)),
             rtp_send: Arc::new(AsyncMutex::new(None)),
             webrtc_output_mode: Arc::new(AtomicU8::new(BRIDGE_OUTPUT_PEER)),
@@ -396,6 +460,14 @@ impl BridgePeer {
     /// Start the bridge - begin forwarding media between sides
     /// Optimized: Merged bidirectional forwarding into a single task to reduce Tokio scheduling overhead
     pub async fn start_bridge(&self) {
+        if self
+            .forwarding_started
+            .swap(true, Ordering::AcqRel)
+        {
+            debug!(bridge_id = %self.id, "Media bridge forwarding already started");
+            return;
+        }
+
         // Extract video senders now (before spawning) so PLI forwarder tasks can use them
         let webrtc_video_sender = self.webrtc_video_sender.lock().await.clone();
         let rtp_video_sender = self.rtp_video_sender.lock().await.clone();
@@ -480,6 +552,27 @@ impl BridgePeer {
         self.rtp_send.lock().await.clone()
     }
 
+    pub fn set_dtmf_sink(
+        &self,
+        endpoint: BridgeEndpoint,
+        payload_type: u8,
+        handler: Arc<dyn Fn(char) + Send + Sync + 'static>,
+    ) {
+        let mut sink = self.dtmf_sink.write();
+        *sink = Some(BridgeDtmfSink {
+            endpoint,
+            payload_type,
+            handler,
+        });
+
+        debug!(
+            bridge_id = %self.id,
+            endpoint = ?endpoint,
+            payload_type,
+            "Bridge DTMF sink installed"
+        );
+    }
+
     pub async fn replace_output_with_file(
         &self,
         endpoint: BridgeEndpoint,
@@ -505,6 +598,38 @@ impl BridgePeer {
             bridge_id = %self.id,
             endpoint = ?endpoint,
             "Bridge output replaced with file source"
+        );
+        Ok(())
+    }
+
+    pub async fn replace_output_with_silence(
+        &self,
+        endpoint: BridgeEndpoint,
+        codec_info: crate::media::negotiate::CodecInfo,
+    ) -> Result<()> {
+        match endpoint {
+            BridgeEndpoint::WebRtc => self.get_webrtc_sender().await,
+            BridgeEndpoint::Rtp => self.get_rtp_sender().await,
+        }
+        .ok_or_else(|| anyhow::anyhow!("bridge {:?} output sender is not ready", endpoint))?;
+
+        let track = crate::media::FileTrack::new(format!("{}-{:?}-silence", self.id, endpoint))
+            .with_loop(true)
+            .with_codec_info(codec_info);
+        let source = track.create_playback_source()?;
+        let source_slot = Arc::clone(self.file_source(endpoint));
+        {
+            let mut guard = source_slot.lock().await;
+            *guard = Some(source);
+        }
+
+        self.output_mode(endpoint)
+            .store(BRIDGE_OUTPUT_FILE, Ordering::Release);
+
+        info!(
+            bridge_id = %self.id,
+            endpoint = ?endpoint,
+            "Bridge output replaced with silence source"
         );
         Ok(())
     }
@@ -655,6 +780,7 @@ impl BridgePeer {
         let w2r_stats = Arc::clone(&self.webrtc_to_rtp_stats);
         let r2w_stats = Arc::clone(&self.rtp_to_webrtc_stats);
         let recorder = self.recorder.clone();
+        let dtmf_sink = Arc::clone(&self.dtmf_sink);
 
         tokio::spawn(async move {
             // Create fused receivers for both directions
@@ -700,6 +826,7 @@ impl BridgePeer {
                                         Arc::clone(&w2r_stats),
                                         if !is_video { recorder.clone() } else { None },
                                         if !is_video { Some(RecLeg::A) } else { None },
+                                        Arc::clone(&dtmf_sink),
                                     ).await;
                                 }
                                 webrtc_recv = Box::pin(webrtc_pc.recv());
@@ -745,6 +872,7 @@ impl BridgePeer {
                                         Arc::clone(&r2w_stats),
                                         if !is_video { recorder.clone() } else { None },
                                         if !is_video { Some(RecLeg::B) } else { None },
+                                        Arc::clone(&dtmf_sink),
                                     ).await;
                                 }
                                 rtp_recv = Box::pin(rtp_pc.recv());
@@ -775,6 +903,7 @@ impl BridgePeer {
         leg_stats: Arc<LegStats>,
         recorder: Option<Arc<parking_lot::RwLock<Option<Recorder>>>>,
         recorder_leg: Option<RecLeg>,
+        dtmf_sink: Arc<parking_lot::RwLock<Option<BridgeDtmfSink>>>,
     ) {
         // Get the sender channel from weak pointer
         let sender = if let Some(strong) = sender_weak.upgrade() {
@@ -809,6 +938,7 @@ impl BridgePeer {
             }
 
         let is_video = track.kind() == MediaKind::Video;
+        let mut dtmf_detector = BridgeDtmfDetector::default();
         let mut packet_count: u64 = 0;
         // Last seen RTP sequence number for loss estimation
         let mut last_seq: Option<u16> = None;
@@ -842,6 +972,14 @@ impl BridgePeer {
                     match sample_result {
                         Ok(sample) => {
                             packet_count += 1;
+                            if !is_video {
+                                Self::observe_dtmf_sample(
+                                    &dtmf_sink,
+                                    path.source_endpoint(),
+                                    &sample,
+                                    &mut dtmf_detector,
+                                );
+                            }
                             let mode = output_mode.load(Ordering::Acquire);
                             if !is_video && mode != BRIDGE_OUTPUT_PEER {
                                 if packet_count == 1 {
@@ -1004,6 +1142,31 @@ impl BridgePeer {
         }
     }
 
+    fn observe_dtmf_sample(
+        dtmf_sink: &Arc<parking_lot::RwLock<Option<BridgeDtmfSink>>>,
+        endpoint: BridgeEndpoint,
+        sample: &MediaSample,
+        detector: &mut BridgeDtmfDetector,
+    ) {
+        let Some(sink) = dtmf_sink.read().clone() else {
+            return;
+        };
+        if sink.endpoint != endpoint {
+            return;
+        }
+
+        let MediaSample::Audio(frame) = sample else {
+            return;
+        };
+        if frame.payload_type != Some(sink.payload_type) {
+            return;
+        }
+
+        if let Some(digit) = detector.observe(&frame.data, frame.rtp_timestamp) {
+            (sink.handler)(digit);
+        }
+    }
+
     /// Forward media from a track to a sender channel.
     /// Spawns a sub-task; used by the PC-event-driven start paths.
     #[allow(clippy::too_many_arguments)]
@@ -1018,6 +1181,7 @@ impl BridgePeer {
         leg_stats: Arc<LegStats>,
         recorder: Option<Arc<parking_lot::RwLock<Option<Recorder>>>>,
         recorder_leg: Option<RecLeg>,
+        dtmf_sink: Arc<parking_lot::RwLock<Option<BridgeDtmfSink>>>,
     ) {
         tokio::spawn(async move {
             Self::run_forward_loop(
@@ -1031,6 +1195,7 @@ impl BridgePeer {
                 leg_stats,
                 recorder,
                 recorder_leg,
+                dtmf_sink,
             )
             .await;
         });

--- a/src/media/bridge.rs
+++ b/src/media/bridge.rs
@@ -55,7 +55,7 @@ use rustrtc::{
 };
 use std::sync::{
     Arc,
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicU8, AtomicU64, Ordering},
 };
 use tokio::sync::Mutex as AsyncMutex;
 use tokio_util::sync::CancellationToken;
@@ -63,6 +63,17 @@ use tracing::{debug, info, trace, warn};
 
 /// Type alias for the sender channel
 pub type MediaSender = SampleStreamSource;
+
+const BRIDGE_OUTPUT_PEER: u8 = 0;
+const BRIDGE_OUTPUT_FILE: u8 = 1;
+const BRIDGE_OUTPUT_MUTED: u8 = 2;
+
+/// One media endpoint owned by a BridgePeer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BridgeEndpoint {
+    WebRtc,
+    Rtp,
+}
 
 /// Maximum RTP payload size for H264 fragmentation.
 /// Standard Ethernet MTU (1500) minus IP (20) + UDP (8) + SRTP overhead (~20) + RTP (12) + FU-A headers (2).
@@ -133,6 +144,15 @@ impl ForwardPath {
 impl std::fmt::Display for ForwardPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}→{}", self.from.as_str(), self.to.as_str())
+    }
+}
+
+fn output_mode_name(mode: u8) -> &'static str {
+    match mode {
+        BRIDGE_OUTPUT_PEER => "peer",
+        BRIDGE_OUTPUT_FILE => "file",
+        BRIDGE_OUTPUT_MUTED => "muted",
+        _ => "unknown",
     }
 }
 
@@ -224,6 +244,10 @@ pub struct BridgePeer {
     /// Audio sender channels for forwarding
     webrtc_send: Arc<AsyncMutex<Option<MediaSender>>>,
     rtp_send: Arc<AsyncMutex<Option<MediaSender>>>,
+    webrtc_output_mode: Arc<AtomicU8>,
+    rtp_output_mode: Arc<AtomicU8>,
+    webrtc_file_source: Arc<AsyncMutex<Option<crate::media::FileTrackPlaybackSource>>>,
+    rtp_file_source: Arc<AsyncMutex<Option<crate::media::FileTrackPlaybackSource>>>,
     /// Video sender channels for forwarding
     webrtc_video_send: Arc<AsyncMutex<Option<MediaSender>>>,
     rtp_video_send: Arc<AsyncMutex<Option<MediaSender>>>,
@@ -256,6 +280,10 @@ impl BridgePeer {
             recorder: None,
             webrtc_send: Arc::new(AsyncMutex::new(None)),
             rtp_send: Arc::new(AsyncMutex::new(None)),
+            webrtc_output_mode: Arc::new(AtomicU8::new(BRIDGE_OUTPUT_PEER)),
+            rtp_output_mode: Arc::new(AtomicU8::new(BRIDGE_OUTPUT_PEER)),
+            webrtc_file_source: Arc::new(AsyncMutex::new(None)),
+            rtp_file_source: Arc::new(AsyncMutex::new(None)),
             webrtc_video_send: Arc::new(AsyncMutex::new(None)),
             rtp_video_send: Arc::new(AsyncMutex::new(None)),
             webrtc_track: AsyncMutex::new(None),
@@ -294,6 +322,25 @@ impl BridgePeer {
         *self.rtp_track.lock().await = Some(rtp_track.clone());
         let _ = self.rtp_pc().add_track(rtp_track, rtp_params);
         *self.rtp_send.lock().await = Some(rtp_tx);
+
+        let mut tasks = self.bridge_tasks.lock().await;
+        tasks.push(Self::spawn_file_output_clock(
+            self.id.clone(),
+            BridgeEndpoint::WebRtc,
+            self.webrtc_send.lock().await.clone(),
+            Arc::clone(&self.webrtc_file_source),
+            Arc::clone(&self.webrtc_output_mode),
+            self.cancel_token.clone(),
+        ));
+        tasks.push(Self::spawn_file_output_clock(
+            self.id.clone(),
+            BridgeEndpoint::Rtp,
+            self.rtp_send.lock().await.clone(),
+            Arc::clone(&self.rtp_file_source),
+            Arc::clone(&self.rtp_output_mode),
+            self.cancel_token.clone(),
+        ));
+        drop(tasks);
 
         // Setup video senders if video codecs are configured
         if let Some(ref webrtc_video_params) = self.webrtc_video_codec {
@@ -433,6 +480,153 @@ impl BridgePeer {
         self.rtp_send.lock().await.clone()
     }
 
+    pub async fn replace_output_with_file(
+        &self,
+        endpoint: BridgeEndpoint,
+        track: &crate::media::FileTrack,
+    ) -> Result<()> {
+        match endpoint {
+            BridgeEndpoint::WebRtc => self.get_webrtc_sender().await,
+            BridgeEndpoint::Rtp => self.get_rtp_sender().await,
+        }
+        .ok_or_else(|| anyhow::anyhow!("bridge {:?} output sender is not ready", endpoint))?;
+
+        let source = track.create_playback_source()?;
+        let source_slot = Arc::clone(self.file_source(endpoint));
+        {
+            let mut guard = source_slot.lock().await;
+            *guard = Some(source);
+        }
+
+        self.output_mode(endpoint)
+            .store(BRIDGE_OUTPUT_FILE, Ordering::Release);
+
+        info!(
+            bridge_id = %self.id,
+            endpoint = ?endpoint,
+            "Bridge output replaced with file source"
+        );
+        Ok(())
+    }
+
+    pub fn replace_output_with_peer(&self, endpoint: BridgeEndpoint) {
+        self.output_mode(endpoint)
+            .store(BRIDGE_OUTPUT_PEER, Ordering::Release);
+        info!(
+            bridge_id = %self.id,
+            endpoint = ?endpoint,
+            "Bridge output replaced with peer source"
+        );
+    }
+
+    pub fn mute_output(&self, endpoint: BridgeEndpoint) {
+        self.output_mode(endpoint)
+            .store(BRIDGE_OUTPUT_MUTED, Ordering::Release);
+        debug!(
+            bridge_id = %self.id,
+            endpoint = ?endpoint,
+            "Bridge output muted"
+        );
+    }
+
+    fn output_mode(&self, endpoint: BridgeEndpoint) -> &Arc<AtomicU8> {
+        match endpoint {
+            BridgeEndpoint::WebRtc => &self.webrtc_output_mode,
+            BridgeEndpoint::Rtp => &self.rtp_output_mode,
+        }
+    }
+
+    fn file_source(
+        &self,
+        endpoint: BridgeEndpoint,
+    ) -> &Arc<AsyncMutex<Option<crate::media::FileTrackPlaybackSource>>> {
+        match endpoint {
+            BridgeEndpoint::WebRtc => &self.webrtc_file_source,
+            BridgeEndpoint::Rtp => &self.rtp_file_source,
+        }
+    }
+
+    fn spawn_file_output_clock(
+        bridge_id: String,
+        endpoint: BridgeEndpoint,
+        sender: Option<MediaSender>,
+        source_slot: Arc<AsyncMutex<Option<crate::media::FileTrackPlaybackSource>>>,
+        output_mode: Arc<AtomicU8>,
+        cancel_token: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(20));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        if output_mode.load(Ordering::Acquire) != BRIDGE_OUTPUT_FILE {
+                            continue;
+                        }
+
+                        let sample = {
+                            let mut guard = source_slot.lock().await;
+                            let Some(source) = guard.as_mut() else {
+                                output_mode.store(BRIDGE_OUTPUT_MUTED, Ordering::Release);
+                                continue;
+                            };
+                            source.next_audio_sample()
+                        };
+
+                        let Some(sample) = sample else {
+                            output_mode.store(BRIDGE_OUTPUT_MUTED, Ordering::Release);
+                            let mut guard = source_slot.lock().await;
+                            guard.take();
+                            debug!(
+                                bridge_id = %bridge_id,
+                                endpoint = ?endpoint,
+                                "Bridge file output completed"
+                            );
+                            continue;
+                        };
+
+                        let Some(sender) = sender.as_ref() else {
+                            warn!(
+                                bridge_id = %bridge_id,
+                                endpoint = ?endpoint,
+                                "Bridge file output sender is unavailable"
+                            );
+                            break;
+                        };
+
+                        match sender.try_send(sample.clone()) {
+                            Ok(()) => {}
+                            Err(MediaError::WouldBlock) => {
+                                if let Err(error) = sender.send(sample).await {
+                                    warn!(
+                                        bridge_id = %bridge_id,
+                                        endpoint = ?endpoint,
+                                        error = %error,
+                                        "Bridge file output send failed"
+                                    );
+                                    break;
+                                }
+                            }
+                            Err(error) => {
+                                warn!(
+                                    bridge_id = %bridge_id,
+                                    endpoint = ?endpoint,
+                                    error = ?error,
+                                    "Bridge file output send failed"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
     /// Get the WebRTC-side track (for test consumption)
     pub async fn get_webrtc_track(&self) -> Option<Arc<SampleStreamTrack>> {
         self.webrtc_track.lock().await.clone()
@@ -452,6 +646,8 @@ impl BridgePeer {
         let rtp_pc = self.rtp_pc.clone();
         let rtp_send = Arc::downgrade(&self.rtp_send);
         let webrtc_send = Arc::downgrade(&self.webrtc_send);
+        let rtp_output_mode = Arc::clone(&self.rtp_output_mode);
+        let webrtc_output_mode = Arc::clone(&self.webrtc_output_mode);
         let rtp_video_send = Arc::downgrade(&self.rtp_video_send);
         let webrtc_video_send = Arc::downgrade(&self.webrtc_video_send);
         let cancel_token = self.cancel_token.clone();
@@ -497,6 +693,7 @@ impl BridgePeer {
                                         bridge_id.clone(),
                                         track,
                                         sender,
+                                        Arc::clone(&rtp_output_mode),
                                         cancel_token.clone(),
                                         ForwardPath::new(LegTransport::WebRtc, LegTransport::Rtp),
                                         None, // no audio fallback in WebRTC→RTP direction
@@ -541,6 +738,7 @@ impl BridgePeer {
                                         bridge_id.clone(),
                                         track,
                                         sender,
+                                        Arc::clone(&webrtc_output_mode),
                                         cancel_token.clone(),
                                         ForwardPath::new(LegTransport::Rtp, LegTransport::WebRtc),
                                         if is_video { Some(webrtc_send.clone()) } else { None },
@@ -570,6 +768,7 @@ impl BridgePeer {
         bridge_id: String,
         track: Arc<dyn MediaStreamTrack>,
         sender_weak: std::sync::Weak<AsyncMutex<Option<MediaSender>>>,
+        output_mode: Arc<AtomicU8>,
         cancel_token: CancellationToken,
         path: ForwardPath,
         audio_fallback_weak: Option<std::sync::Weak<AsyncMutex<Option<MediaSender>>>>,
@@ -643,6 +842,18 @@ impl BridgePeer {
                     match sample_result {
                         Ok(sample) => {
                             packet_count += 1;
+                            let mode = output_mode.load(Ordering::Acquire);
+                            if !is_video && mode != BRIDGE_OUTPUT_PEER {
+                                if packet_count == 1 {
+                                    debug!(
+                                        bridge_id = %bridge_id,
+                                        direction = %path,
+                                        output_source = output_mode_name(mode),
+                                        "Peer media suppressed by bridge output source"
+                                    );
+                                }
+                                continue;
+                            }
                             if packet_count == 1 {
                                 debug!(bridge_id = %bridge_id, direction = %path, kind = ?sample.kind(), "First media sample forwarded");
                             }
@@ -800,6 +1011,7 @@ impl BridgePeer {
         bridge_id: String,
         track: Arc<dyn MediaStreamTrack>,
         sender_weak: std::sync::Weak<AsyncMutex<Option<MediaSender>>>,
+        output_mode: Arc<AtomicU8>,
         cancel_token: CancellationToken,
         path: ForwardPath,
         audio_fallback_weak: Option<std::sync::Weak<AsyncMutex<Option<MediaSender>>>>,
@@ -812,6 +1024,7 @@ impl BridgePeer {
                 bridge_id,
                 track,
                 sender_weak,
+                output_mode,
                 cancel_token,
                 path,
                 audio_fallback_weak,
@@ -1127,11 +1340,32 @@ impl BridgePeerBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::media::{CodecType, RtpTrackBuilder};
+    use crate::media::{CodecType, FileTrack, RtpTrackBuilder};
     use rustrtc::{
         TransportMode,
         sdp::{SdpType, SessionDescription},
     };
+
+    fn create_test_wav_file(path: &str, num_samples: usize) -> Result<()> {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 8000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer =
+            hound::WavWriter::create(path, spec).map_err(|e| anyhow::anyhow!("WavWriter: {e}"))?;
+        for i in 0..num_samples {
+            let sample = ((i as f32 / 8.0).sin() * 1000.0) as i16;
+            writer
+                .write_sample(sample)
+                .map_err(|e| anyhow::anyhow!("write_sample: {e}"))?;
+        }
+        writer
+            .finalize()
+            .map_err(|e| anyhow::anyhow!("finalize: {e}"))?;
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_bridge_peer_creation() {
@@ -1256,6 +1490,59 @@ mod tests {
 
         // Clean up
         bridge.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_bridge_file_output_polls_file_track_source() {
+        let temp_dir = std::env::temp_dir();
+        let test_file = temp_dir.join("test_bridge_file_output.wav");
+        create_test_wav_file(test_file.to_str().unwrap(), 800).unwrap();
+
+        let bridge = BridgePeerBuilder::new("test-bridge-file-output".to_string())
+            .with_rtp_port_range(25100, 25200)
+            .build();
+        bridge.setup_bridge().await.unwrap();
+
+        let track = FileTrack::new("bridge-file-output".to_string())
+            .with_path(test_file.to_string_lossy().to_string())
+            .with_loop(false)
+            .with_codec_info(crate::media::negotiate::CodecInfo {
+                payload_type: 0,
+                codec: CodecType::PCMU,
+                clock_rate: 8000,
+                channels: 1,
+            });
+
+        bridge
+            .replace_output_with_file(BridgeEndpoint::Rtp, &track)
+            .await
+            .unwrap();
+        drop(track);
+
+        let rtp_track = bridge
+            .get_rtp_track()
+            .await
+            .expect("bridge RTP output track should exist");
+        let mut frame_count = 0;
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(400);
+        while tokio::time::Instant::now() < deadline && frame_count < 3 {
+            match tokio::time::timeout(tokio::time::Duration::from_millis(100), rtp_track.recv())
+                .await
+            {
+                Ok(Ok(MediaSample::Audio(_))) => frame_count += 1,
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) => break,
+                Err(_) => {}
+            }
+        }
+
+        bridge.stop().await;
+        let _ = std::fs::remove_file(&test_file);
+
+        assert!(
+            frame_count >= 3,
+            "bridge should poll the FileTrack source and send audio without a FileTrack-owned task"
+        );
     }
 
     /// Test that BridgePeer correctly handles SDP format differences

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -4,7 +4,7 @@ use audio_codec::CodecType;
 use rustrtc::{
     Attribute, IceServer, IceTransportPolicy, MediaKind, PeerConnection, RtcConfiguration,
     RtpCodecParameters, SdpType, SessionDescription, TransceiverDirection, TransportMode,
-    media::SampleStreamSource,
+    media::{AudioFrame, MediaSample, SampleStreamSource},
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -678,6 +678,7 @@ pub struct FileTrack {
     bind_ip: Option<String>,
     audio_source_manager: Option<Arc<audio_source::AudioSourceManager>>,
     muted: std::sync::atomic::AtomicBool,
+    lifetime_guard: Arc<()>,
 }
 
 impl Clone for FileTrack {
@@ -700,7 +701,55 @@ impl Clone for FileTrack {
             muted: std::sync::atomic::AtomicBool::new(
                 self.muted.load(std::sync::atomic::Ordering::Relaxed),
             ),
+            lifetime_guard: self.lifetime_guard.clone(),
         }
+    }
+}
+
+pub(crate) struct FileTrackPlaybackSource {
+    audio_source_manager: Arc<audio_source::AudioSourceManager>,
+    encoder: Box<dyn audio_codec::Encoder>,
+    codec_info: negotiate::CodecInfo,
+    samples_per_frame: usize,
+    rtp_ticks_per_frame: u32,
+    rtp_timestamp: u32,
+    sequence_number: u16,
+    completion_notify: Arc<tokio::sync::Notify>,
+    loop_playback: bool,
+}
+
+impl FileTrackPlaybackSource {
+    pub(crate) fn next_audio_sample(&mut self) -> Option<MediaSample> {
+        let mut pcm_buf = vec![0i16; self.samples_per_frame];
+        let mut read = self.audio_source_manager.read_samples(&mut pcm_buf);
+
+        if read == 0 && self.loop_playback {
+            read = self.audio_source_manager.read_samples(&mut pcm_buf);
+        }
+
+        if read == 0 {
+            debug!("FileTrack playback completed (source exhausted)");
+            self.completion_notify.notify_waiters();
+            return None;
+        }
+
+        let encoded = self.encoder.encode(&pcm_buf[..read]);
+        let frame = AudioFrame {
+            rtp_timestamp: self.rtp_timestamp,
+            clock_rate: self.codec_info.clock_rate,
+            data: encoded.into(),
+            sequence_number: Some(self.sequence_number),
+            payload_type: Some(self.codec_info.payload_type),
+            marker: false,
+            header_extension: None,
+            raw_packet: None,
+            source_addr: None,
+        };
+
+        self.rtp_timestamp = self.rtp_timestamp.wrapping_add(self.rtp_ticks_per_frame);
+        self.sequence_number = self.sequence_number.wrapping_add(1);
+
+        Some(MediaSample::Audio(frame))
     }
 }
 
@@ -730,6 +779,7 @@ impl FileTrack {
             bind_ip: None,
             audio_source_manager: None,
             muted: std::sync::atomic::AtomicBool::new(false),
+            lifetime_guard: Arc::new(()),
         }
     }
 
@@ -844,15 +894,8 @@ impl FileTrack {
     pub async fn start_playback(&self) -> Result<()> {
         self.start_playback_on(None).await
     }
-    /// Push audio frames through an existing SampleStreamSource (e.g. from an
-    /// RtcTrack).  Unlike start_playback_on, this does NOT create a new RTP
-    /// sender or change SSRC — it injects decoded frames into the same track
-    /// that was originally negotiated in the SDP, avoiding SSRC mismatches
-    /// that can break audio in WebRTC (DTLS/SRTP) mode.
-    pub async fn start_playback_on_sender(&self, sender: SampleStreamSource) -> Result<()> {
-        use audio_codec::create_encoder;
-        use rustrtc::media::{AudioFrame, MediaSample};
 
+    pub(crate) fn create_playback_source(&self) -> Result<FileTrackPlaybackSource> {
         let file_path = self
             .file_path
             .as_ref()
@@ -876,21 +919,7 @@ impl FileTrack {
                 channels: codec.channels(),
             }
         });
-        let codec = selected.codec;
-        let payload_type = selected.payload_type;
-        let frame_timing = audio_frame_timing(codec, selected.clock_rate);
-        let samples_per_frame = frame_timing.pcm_samples_per_frame;
-
-        debug!(
-            file = %file_path,
-            loop_playback = self.loop_playback,
-            ?codec,
-            samples_per_frame,
-            pcm_sample_rate = frame_timing.pcm_sample_rate,
-            rtp_ticks_per_frame = frame_timing.rtp_ticks_per_frame,
-            "FileTrack start_playback_on_sender"
-        );
-
+        let frame_timing = audio_frame_timing(selected.codec, selected.clock_rate);
         let audio_source_manager = {
             if let Some(ref mgr) = self.audio_source_manager {
                 mgr.clone()
@@ -903,67 +932,27 @@ impl FileTrack {
             }
         };
 
-        let completion_notify = self.completion_notify.clone();
-        let cancel_token = self.cancel_token.clone();
-        let loop_playback = self.loop_playback;
+        debug!(
+            file = %file_path,
+            loop_playback = self.loop_playback,
+            codec = ?selected.codec,
+            samples_per_frame = frame_timing.pcm_samples_per_frame,
+            pcm_sample_rate = frame_timing.pcm_sample_rate,
+            rtp_ticks_per_frame = frame_timing.rtp_ticks_per_frame,
+            "FileTrack playback source created"
+        );
 
-        crate::utils::spawn(async move {
-            let mut encoder = create_encoder(codec);
-            let mut rtp_timestamp: u32 = rand::random();
-            let mut sequence_number: u16 = rand::random();
-            let interval_ms = 20u64;
-            let mut interval =
-                tokio::time::interval(tokio::time::Duration::from_millis(interval_ms));
-
-            loop {
-                tokio::select! {
-                    _ = cancel_token.cancelled() => {
-                        debug!("FileTrack playback cancelled");
-                        completion_notify.notify_waiters();
-                        break;
-                    }
-                    _ = interval.tick() => {
-                        let mut pcm_buf = vec![0i16; samples_per_frame];
-                        let read = audio_source_manager.read_samples(&mut pcm_buf);
-
-                        if read == 0 {
-                            if !loop_playback {
-                                debug!("FileTrack playback completed (file exhausted)");
-                                completion_notify.notify_waiters();
-                                break;
-                            }
-                            continue;
-                        }
-
-                        let encoded = encoder.encode(&pcm_buf[..read]);
-
-                        let frame = AudioFrame {
-                            rtp_timestamp,
-                            clock_rate: selected.clock_rate,
-                            data: encoded.into(),
-                            sequence_number: Some(sequence_number),
-                            payload_type: Some(payload_type),
-                            marker: false,
-                            header_extension: None,
-                            raw_packet: None,
-                            source_addr: None,
-                        };
-
-                        rtp_timestamp =
-                            rtp_timestamp.wrapping_add(frame_timing.rtp_ticks_per_frame);
-                        sequence_number = sequence_number.wrapping_add(1);
-
-                        if let Err(e) = sender.send(MediaSample::Audio(frame)).await {
-                            debug!("FileTrack sender.send failed (receiver gone): {}", e);
-                            completion_notify.notify_waiters();
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-
-        Ok(())
+        Ok(FileTrackPlaybackSource {
+            audio_source_manager,
+            encoder: audio_codec::create_encoder(selected.codec),
+            codec_info: selected,
+            samples_per_frame: frame_timing.pcm_samples_per_frame,
+            rtp_ticks_per_frame: frame_timing.rtp_ticks_per_frame,
+            rtp_timestamp: rand::random(),
+            sequence_number: rand::random(),
+            completion_notify: self.completion_notify.clone(),
+            loop_playback: self.loop_playback,
+        })
     }
 
     pub async fn start_playback_on(&self, target_pc: Option<PeerConnection>) -> Result<()> {
@@ -1218,6 +1207,7 @@ impl Track for FileTrack {
 
     async fn stop(&self) {
         self.cancel_token.cancel();
+        self.completion_notify.notify_waiters();
     }
 
     async fn get_peer_connection(&self) -> Option<PeerConnection> {
@@ -1241,9 +1231,11 @@ impl Track for FileTrack {
 
 impl Drop for FileTrack {
     fn drop(&mut self) {
-        debug!(track_id = %self.track_id, "FileTrack dropping, closing PeerConnection");
-        self.cancel_token.cancel();
-        self.pc.close();
+        if Arc::strong_count(&self.lifetime_guard) == 1 {
+            debug!(track_id = %self.track_id, "FileTrack dropping, closing PeerConnection");
+            self.cancel_token.cancel();
+            self.pc.close();
+        }
     }
 }
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -896,14 +896,13 @@ impl FileTrack {
     }
 
     pub(crate) fn create_playback_source(&self) -> Result<FileTrackPlaybackSource> {
-        let file_path = self
-            .file_path
-            .as_ref()
-            .ok_or_else(|| anyhow!("No file path set"))?;
+        let file_path = self.file_path.as_deref();
 
-        let is_remote = file_path.starts_with("http://") || file_path.starts_with("https://");
-        if !is_remote && !std::path::Path::new(file_path).exists() {
-            return Err(anyhow!("Audio file not found: {}", file_path));
+        if let Some(file_path) = file_path {
+            let is_remote = file_path.starts_with("http://") || file_path.starts_with("https://");
+            if !is_remote && !std::path::Path::new(file_path).exists() {
+                return Err(anyhow!("Audio file not found: {}", file_path));
+            }
         }
 
         let selected = self.codec_info.clone().unwrap_or_else(|| {
@@ -927,13 +926,17 @@ impl FileTrack {
                 let mgr = Arc::new(audio_source::AudioSourceManager::new(
                     frame_timing.pcm_sample_rate,
                 ));
-                mgr.switch_to_file(file_path.clone(), self.loop_playback)?;
+                if let Some(file_path) = file_path {
+                    mgr.switch_to_file(file_path.to_string(), self.loop_playback)?;
+                } else {
+                    mgr.switch_to_silence();
+                }
                 mgr
             }
         };
 
         debug!(
-            file = %file_path,
+            file = %file_path.unwrap_or("<silence>"),
             loop_playback = self.loop_playback,
             codec = ?selected.codec,
             samples_per_frame = frame_timing.pcm_samples_per_frame,

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -1469,6 +1469,7 @@ impl SipSession {
             Ok(answer) => {
                 self.answer = Some(answer.clone());
                 self.caller_answer_uses_media_bridge = true;
+                self.replace_caller_bridge_output_with_silence().await;
                 Some(answer)
             }
             Err(error) => {
@@ -1482,6 +1483,160 @@ impl SipSession {
                 self.ensure_caller_answer_sdp().await
             }
         }
+    }
+
+    async fn prepare_app_caller_media_bridge(&mut self) -> Option<String> {
+        if let Some(ref answer) = self.answer {
+            return Some(answer.clone());
+        }
+
+        let caller_offer = self.caller_offer.clone()?;
+        let caller_is_webrtc = self.is_caller_webrtc();
+        self.caller_is_webrtc = caller_is_webrtc;
+        self.callee_offer_uses_media_bridge = false;
+
+        let created_bridge = self.media_bridge.is_none();
+        if self.media_bridge.is_none()
+            && let Err(error) = self
+                .create_app_caller_media_bridge(&caller_offer, caller_is_webrtc)
+                .await
+        {
+            warn!(
+                session_id = %self.context.session_id,
+                error = %error,
+                "Application answer: failed to prepare media bridge, falling back to caller media"
+            );
+            self.caller_answer_uses_media_bridge = false;
+            return None;
+        }
+
+        match self.prepare_bridge_caller_answer().await {
+            Ok(answer) => {
+                self.answer = Some(answer.clone());
+                self.caller_answer_uses_media_bridge = true;
+                self.replace_caller_bridge_output_with_silence().await;
+                Some(answer)
+            }
+            Err(error) => {
+                if created_bridge
+                    && let Some(bridge) = self.media_bridge.take()
+                {
+                    bridge.stop().await;
+                }
+                warn!(
+                    session_id = %self.context.session_id,
+                    error = %error,
+                    "Application answer: failed to answer from media bridge, falling back to caller media"
+                );
+                self.caller_answer_uses_media_bridge = false;
+                None
+            }
+        }
+    }
+
+    async fn create_app_caller_media_bridge(
+        &mut self,
+        caller_offer: &str,
+        caller_is_webrtc: bool,
+    ) -> Result<()> {
+        let mut bridge_builder = BridgePeerBuilder::new(format!("{}-app-bridge", self.id))
+            .with_enable_latching(self.server.proxy_config.enable_latching);
+
+        if let (Some(start), Some(end)) = (
+            self.server.rtp_config.start_port,
+            self.server.rtp_config.end_port,
+        ) {
+            bridge_builder = bridge_builder.with_rtp_port_range(start, end);
+        }
+
+        if !caller_is_webrtc && caller_offer.contains("a=group:BUNDLE") {
+            bridge_builder = bridge_builder
+                .with_rtp_sdp_compatibility(rustrtc::config::SdpCompatibilityMode::Standard)
+                .with_enable_latching(true);
+            info!(session_id = %self.id, "RTP caller offered BUNDLE, using Standard SDP mode + latching for app media bridge");
+        }
+
+        if let Some(ref external_ip) = self.server.rtp_config.external_ip {
+            bridge_builder = bridge_builder.with_external_ip(external_ip.clone());
+        }
+        if let Some(ref bind_ip) = self.server.rtp_config.bind_ip {
+            bridge_builder = bridge_builder.with_bind_ip(bind_ip.clone());
+        }
+        if let Some(ref ice_servers) = self.context.dialplan.media.ice_servers {
+            bridge_builder = bridge_builder.with_ice_servers(ice_servers.clone());
+        }
+
+        let caller_codecs =
+            MediaNegotiator::build_caller_answer_codec_list(caller_offer, caller_is_webrtc);
+        let audio_caps: Vec<_> = caller_codecs
+            .iter()
+            .filter_map(|codec| codec.to_audio_capability())
+            .collect();
+        if !audio_caps.is_empty() {
+            bridge_builder = bridge_builder
+                .with_webrtc_audio_capabilities(audio_caps.clone())
+                .with_rtp_audio_capabilities(audio_caps);
+        }
+
+        if let Some(sender) = caller_codecs
+            .iter()
+            .find(|codec| !codec.is_dtmf())
+            .map(|codec| codec.to_params())
+        {
+            bridge_builder = bridge_builder.with_sender_codecs(sender.clone(), sender);
+        }
+
+        if self.context.dialplan.recording.enabled {
+            bridge_builder = bridge_builder.with_recorder(self.recorder.clone());
+        }
+
+        let bridge = bridge_builder.build();
+        bridge.setup_bridge().await?;
+        self.media_bridge = Some(bridge);
+
+        debug!(
+            session_id = %self.context.session_id,
+            caller_is_webrtc,
+            "Application caller media bridge prepared"
+        );
+
+        Ok(())
+    }
+
+    async fn replace_caller_bridge_output_with_silence(&self) {
+        let Some(bridge) = self.media_bridge.as_ref() else {
+            return;
+        };
+
+        if let Err(error) = bridge
+            .replace_output_with_silence(
+                self.caller_bridge_endpoint(),
+                self.caller_output_codec_info(),
+            )
+            .await
+        {
+            warn!(
+                session_id = %self.context.session_id,
+                error = %error,
+                "Failed to install caller bridge silence source"
+            );
+        }
+    }
+
+    fn caller_output_codec_info(&self) -> CodecInfo {
+        self.caller_offer
+            .as_ref()
+            .map(|offer| MediaNegotiator::extract_codec_params(offer).audio)
+            .and_then(|codecs| codecs.first().cloned())
+            .unwrap_or_else(|| {
+                let codec = CodecType::PCMU;
+                CodecInfo {
+                    payload_type: codec.payload_type(),
+                    codec,
+                    clock_rate: codec.clock_rate(),
+                    channels: codec.channels(),
+                }
+            })
     }
 
     async fn prepare_bridge_caller_answer(&self) -> Result<String> {
@@ -2762,18 +2917,6 @@ impl SipSession {
     }
 
     async fn start_caller_ingress_monitor_if_needed(&mut self) {
-        if self
-            .caller_ingress_monitor
-            .as_ref()
-            .is_some_and(|monitor| !monitor.task.is_finished())
-        {
-            return;
-        }
-
-        if self.caller_ingress_monitor.is_some() {
-            self.stop_caller_ingress_monitor().await;
-        }
-
         if self.connected_callee.is_some() {
             return;
         }
@@ -2787,16 +2930,73 @@ impl SipSession {
             return;
         };
 
-        let Some(caller_pc) = Self::get_peer_pc(&self.caller_peer, Self::CALLER_TRACK_ID).await
-        else {
+        let session_id = self.context.session_id.clone();
+        let app_runtime = self.app_runtime.clone();
+        let dtmf_payload_type = dtmf_codec.payload_type;
+
+        if self.caller_answer_uses_media_bridge {
+            if self.caller_ingress_monitor.is_some() {
+                self.stop_caller_ingress_monitor().await;
+            }
+
+            let Some(bridge) = self.media_bridge.as_ref() else {
+                return;
+            };
+            let endpoint = self.caller_bridge_endpoint();
+            bridge.set_dtmf_sink(
+                endpoint,
+                dtmf_payload_type,
+                Arc::new(move |digit| {
+                    let event = serde_json::json!({
+                        "type": "dtmf",
+                        "digit": digit.to_string(),
+                    });
+
+                    if let Err(error) = app_runtime.inject_event(event) {
+                        debug!(
+                            session_id = %session_id,
+                            digit = %digit,
+                            error = %error,
+                            "Bridge DTMF sink observed RTP DTMF with no active app receiver"
+                        );
+                    } else {
+                        debug!(
+                            session_id = %session_id,
+                            digit = %digit,
+                            "Injected RTP DTMF from bridge sink"
+                        );
+                    }
+                }),
+            );
+            bridge.start_bridge().await;
+            info!(
+                session_id = %self.context.session_id,
+                endpoint = ?endpoint,
+                payload_type = dtmf_payload_type,
+                "Installed caller bridge DTMF sink"
+            );
+            return;
+        }
+
+        if self
+            .caller_ingress_monitor
+            .as_ref()
+            .is_some_and(|monitor| !monitor.task.is_finished())
+        {
+            return;
+        }
+
+        if self.caller_ingress_monitor.is_some() {
+            self.stop_caller_ingress_monitor().await;
+        }
+
+        let caller_pc = Self::get_peer_pc(&self.caller_peer, Self::CALLER_TRACK_ID).await;
+        let Some(caller_pc) = caller_pc else {
             return;
         };
 
-        let session_id = self.context.session_id.clone();
-        let app_runtime = self.app_runtime.clone();
         let cancel_token = self.cancel_token.child_token();
         let monitor_cancel = cancel_token.clone();
-        let dtmf_payload_type = dtmf_codec.payload_type;
 
         let task = tokio::spawn(async move {
             let track = loop {
@@ -4640,7 +4840,12 @@ impl SipSession {
         match command {
             CallCommand::Answer { leg_id } => {
                 if leg_id.0 == "caller" {
-                    match self.accept_call(None, None, None).await {
+                    let answer_sdp = if self.app_runtime.is_running() {
+                        self.prepare_app_caller_media_bridge().await
+                    } else {
+                        None
+                    };
+                    match self.accept_call(None, answer_sdp, None).await {
                         Ok(()) => {
                             self.update_leg_state(&leg_id, LegState::Connected);
                             CommandResult::success()
@@ -7749,7 +7954,7 @@ impl crate::call::runtime::conference_media_bridge::AudioReceiver for PeerConnec
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use rustrtc::{MediaKind, PeerConnection, RtcConfiguration};
+    use rustrtc::{MediaKind, PeerConnection, RtcConfiguration, media::MediaStreamTrack};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct TestTrack {
@@ -8098,6 +8303,116 @@ mod tests {
         assert!(pc.is_some(), "bridge-backed caller leg should resolve a PC");
         assert_eq!(caller_peer.get_tracks_call_count(), 0);
         assert_eq!(callee_peer.get_tracks_call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_prepare_app_caller_media_bridge_routes_playback_through_bridge() {
+        use crate::call::{DialDirection, Dialplan, TransactionCookie};
+        use crate::proxy::proxy_call::test_util::tests::MockMediaPeer;
+        use crate::proxy::tests::common::{
+            create_test_request, create_test_server, create_transaction,
+        };
+
+        let (server, _) = create_test_server().await;
+        let request = create_test_request(
+            rsipstack::sip::Method::Invite,
+            "alice",
+            None,
+            "rustpbx.com",
+            None,
+        );
+        let original_request = request.clone();
+        let (tx, _) = create_transaction(request).await;
+        let (state_tx, _state_rx) = mpsc::unbounded_channel();
+        let server_dialog = server
+            .dialog_layer
+            .get_or_create_server_invite(&tx, state_tx, None, None)
+            .expect("failed to create server dialog");
+
+        let context = CallContext {
+            session_id: "test-session".to_string(),
+            dialplan: Arc::new(Dialplan::new(
+                "test-session".to_string(),
+                original_request,
+                DialDirection::Inbound,
+            )),
+            cookie: TransactionCookie::default(),
+            start_time: Instant::now(),
+            original_caller: "sip:alice@rustpbx.com".to_string(),
+            original_callee: "sip:ivr@rustpbx.com".to_string(),
+            max_forwards: 70,
+            dtmf_digits: Vec::new(),
+        };
+
+        let caller_peer = Arc::new(MockMediaPeer::new());
+        let callee_peer = Arc::new(MockMediaPeer::new());
+        let (mut session, _handle, _cmd_rx) = SipSession::new(
+            server.clone(),
+            CancellationToken::new(),
+            None,
+            context,
+            server_dialog,
+            false,
+            caller_peer.clone(),
+            callee_peer,
+        );
+
+        session.caller_offer = Some(
+            concat!(
+                "v=0\r\n",
+                "o=alice 1 1 IN IP4 192.0.2.10\r\n",
+                "s=Talk\r\n",
+                "c=IN IP4 192.0.2.10\r\n",
+                "t=0 0\r\n",
+                "m=audio 40000 RTP/AVP 0 8 101\r\n",
+                "a=rtpmap:0 PCMU/8000\r\n",
+                "a=rtpmap:8 PCMA/8000\r\n",
+                "a=rtpmap:101 telephone-event/8000\r\n",
+                "a=sendrecv\r\n",
+            )
+            .to_string(),
+        );
+
+        let answer = session
+            .prepare_app_caller_media_bridge()
+            .await
+            .expect("app caller bridge answer should be prepared");
+
+        assert!(answer.contains("RTP/AVP"));
+        assert!(session.media_bridge.is_some());
+        assert!(session.caller_answer_uses_media_bridge);
+        assert_eq!(caller_peer.update_track_call_count(), 0);
+
+        let bridge = session
+            .media_bridge
+            .as_ref()
+            .expect("media bridge should exist")
+            .clone();
+        let rtp_track = bridge
+            .get_rtp_track()
+            .await
+            .expect("RTP bridge output track should exist");
+        let silence_sample =
+            tokio::time::timeout(Duration::from_millis(100), rtp_track.recv())
+                .await
+                .expect("bridge silence source should send promptly")
+                .expect("bridge silence source should produce a sample");
+        assert!(
+            matches!(silence_sample, rustrtc::media::MediaSample::Audio(_)),
+            "caller bridge should send silence before file playback is installed"
+        );
+
+        session
+            .play_audio_file("sounds/phone-calling.wav", false, "caller", true)
+            .await
+            .expect("app playback should install a bridge file source");
+
+        assert_eq!(caller_peer.update_track_call_count(), 0);
+        assert_eq!(caller_peer.get_tracks_call_count(), 0);
+
+        if let Some(bridge) = session.media_bridge.take() {
+            bridge.stop().await;
+        }
     }
 
     #[tokio::test]

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -29,7 +29,7 @@ use crate::call::domain::SessionPolicy;
 use crate::call::sip::{ClientDialogGuard, ServerDialogGuard};
 use crate::callrecord::{CallRecordHangupMessage, CallRecordHangupReason, CallRecordSender};
 use crate::config::MediaProxyMode;
-use crate::media::bridge::BridgePeerBuilder;
+use crate::media::bridge::{BridgeEndpoint, BridgePeerBuilder};
 use crate::media::mixer::MediaMixer;
 use crate::media::negotiate::{CodecInfo, MediaNegotiator};
 use crate::media::recorder::Recorder;
@@ -193,6 +193,10 @@ pub struct SipSession {
     caller_ingress_monitor: Option<CallerIngressMonitor>,
 
     pub media_bridge: Option<Arc<crate::media::bridge::BridgePeer>>,
+    caller_answer_uses_media_bridge: bool,
+    callee_offer_uses_media_bridge: bool,
+    media_bridge_started: bool,
+    bridge_playback_track_id: Option<String>,
     pub caller_is_webrtc: bool,
     pub callee_is_webrtc: bool,
     pub conference_bridge: crate::call::runtime::SessionConferenceBridge,
@@ -296,6 +300,7 @@ impl SipSession {
     pub const CALLEE_TRACK_ID: &'static str = "callee-track";
     pub const CALLER_FORWARDING_TRACK_ID: &'static str = "caller-forwarding-track";
     pub const CALLEE_FORWARDING_TRACK_ID: &'static str = "callee-forwarding-track";
+    pub const QUEUE_HOLD_TRACK_ID: &'static str = "queue-hold";
     const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(3);
 
     pub fn with_handle(id: SessionId) -> (SipSessionHandle, mpsc::UnboundedReceiver<CallCommand>) {
@@ -463,6 +468,10 @@ impl SipSession {
             playback_tracks: std::collections::HashMap::new(),
             caller_ingress_monitor: None,
             media_bridge: None,
+            caller_answer_uses_media_bridge: false,
+            callee_offer_uses_media_bridge: false,
+            media_bridge_started: false,
+            bridge_playback_track_id: None,
             caller_is_webrtc: false,
             callee_is_webrtc: false,
             conference_bridge: crate::call::runtime::SessionConferenceBridge::new(),
@@ -1285,7 +1294,7 @@ impl SipSession {
         for (idx, target) in targets.iter().enumerate() {
             info!(index = idx, target = %target.aor, "Trying sequential target");
 
-            match self.try_single_target(target, callee_state_rx).await {
+            match self.try_single_target(target, callee_state_rx, None).await {
                 Ok(()) => {
                     info!(index = idx, "Sequential target succeeded");
                     return Ok(());
@@ -1306,7 +1315,7 @@ impl SipSession {
         callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
     ) -> Result<(), (StatusCode, Option<String>)> {
         if let Some(target) = targets.first() {
-            self.try_single_target(target, callee_state_rx).await
+            self.try_single_target(target, callee_state_rx, None).await
         } else {
             Err((
                 StatusCode::TemporarilyUnavailable,
@@ -1349,7 +1358,8 @@ impl SipSession {
 
         if plan.accept_immediately {
             info!("Queue: answering call immediately");
-            if let Err(e) = self.accept_call(None, None, None).await {
+            let caller_answer = self.prepare_queue_early_answer(&resolved_agents).await;
+            if let Err(e) = self.accept_call(None, caller_answer, None).await {
                 warn!(error = %e, "Failed to answer call in queue");
             }
         }
@@ -1358,14 +1368,33 @@ impl SipSession {
             if let Some(ref audio_file) = hold.audio_file {
                 info!(file = %audio_file, "Queue: starting hold music");
 
-                self.play_audio_file(audio_file, false, "caller", hold.loop_playback)
+                match self
+                    .play_audio_file(
+                        audio_file,
+                        false,
+                        Self::QUEUE_HOLD_TRACK_ID,
+                        hold.loop_playback,
+                    )
                     .await
-                    .ok()
+                {
+                    Ok(()) => {
+                        info!(track_id = %Self::QUEUE_HOLD_TRACK_ID, "Queue: hold music started");
+                        true
+                    }
+                    Err(error) => {
+                        warn!(
+                            error = %error,
+                            track_id = %Self::QUEUE_HOLD_TRACK_ID,
+                            "Queue: failed to start hold music"
+                        );
+                        false
+                    }
+                }
             } else {
-                None
+                false
             }
         } else {
-            None
+            false
         };
 
         let result = match &plan.dial_strategy {
@@ -1380,8 +1409,10 @@ impl SipSession {
             None => Ok(()),
         };
 
-        if hold_handle.is_some() {
+        if hold_handle {
             info!("Queue: stopping hold music");
+            self.stop_playback_track(Self::QUEUE_HOLD_TRACK_ID, false)
+                .await;
         }
 
         match result {
@@ -1394,6 +1425,108 @@ impl SipSession {
                 self.execute_queue_fallback(plan).await
             }
         }
+    }
+
+    async fn prepare_queue_early_answer(
+        &mut self,
+        agents: &[crate::call::Location],
+    ) -> Option<String> {
+        let caller_is_webrtc = self.is_caller_webrtc();
+        self.caller_is_webrtc = caller_is_webrtc;
+
+        let Some(first_agent) = agents.first() else {
+            return self.ensure_caller_answer_sdp().await;
+        };
+
+        let callee_is_webrtc = first_agent.supports_webrtc;
+        self.callee_is_webrtc = callee_is_webrtc;
+
+        if caller_is_webrtc == callee_is_webrtc {
+            self.caller_answer_uses_media_bridge = false;
+            self.callee_offer_uses_media_bridge = false;
+            return self.ensure_caller_answer_sdp().await;
+        }
+
+        if self.media_bridge.is_none() {
+            match self.create_callee_track(callee_is_webrtc).await {
+                Ok(callee_offer) => {
+                    self.callee_offer = Some(callee_offer);
+                }
+                Err(error) => {
+                    warn!(
+                        session_id = %self.context.session_id,
+                        error = %error,
+                        "Queue early answer: failed to prepare bridge, falling back to caller media"
+                    );
+                    self.caller_answer_uses_media_bridge = false;
+                    self.callee_offer_uses_media_bridge = false;
+                    return self.ensure_caller_answer_sdp().await;
+                }
+            }
+        }
+
+        match self.prepare_bridge_caller_answer().await {
+            Ok(answer) => {
+                self.answer = Some(answer.clone());
+                self.caller_answer_uses_media_bridge = true;
+                Some(answer)
+            }
+            Err(error) => {
+                warn!(
+                    session_id = %self.context.session_id,
+                    error = %error,
+                    "Queue early answer: failed to answer from bridge, falling back to caller media"
+                );
+                self.caller_answer_uses_media_bridge = false;
+                self.callee_offer_uses_media_bridge = false;
+                self.ensure_caller_answer_sdp().await
+            }
+        }
+    }
+
+    async fn prepare_bridge_caller_answer(&self) -> Result<String> {
+        let caller_offer = self
+            .caller_offer
+            .as_deref()
+            .ok_or_else(|| anyhow!("No caller offer available for bridge answer"))?;
+        let bridge = self
+            .media_bridge
+            .as_ref()
+            .ok_or_else(|| anyhow!("No media bridge available for caller answer"))?;
+
+        let pc = if self.caller_is_webrtc {
+            bridge.webrtc_pc().clone()
+        } else {
+            bridge.rtp_pc().clone()
+        };
+
+        if let Some(local_description) = pc.local_description() {
+            return Ok(local_description.to_sdp_string());
+        }
+
+        if pc.remote_description().is_none() {
+            let offer =
+                rustrtc::SessionDescription::parse(rustrtc::SdpType::Offer, caller_offer)
+                    .map_err(|e| anyhow!("Failed to parse caller offer SDP: {}", e))?;
+            pc.set_remote_description(offer)
+                .await
+                .map_err(|e| anyhow!("Failed to set bridge caller remote description: {}", e))?;
+        }
+
+        let answer = pc
+            .create_answer()
+            .await
+            .map_err(|e| anyhow!("Failed to create bridge caller answer: {}", e))?;
+        pc.set_local_description(answer)
+            .map_err(|e| anyhow!("Failed to set bridge caller local answer: {}", e))?;
+
+        if self.caller_is_webrtc {
+            pc.wait_for_gathering_complete().await;
+        }
+
+        pc.local_description()
+            .map(|desc| desc.to_sdp_string())
+            .ok_or_else(|| anyhow!("Bridge caller side has no local answer"))
     }
 
     /// Resolve queue targets to the concrete locations used for dialing.
@@ -1544,7 +1677,10 @@ impl SipSession {
         for (idx, agent) in agents.iter().enumerate() {
             info!(index = idx, agent = %agent.aor, "Queue: trying agent");
 
-            match self.try_single_target(agent, callee_state_rx).await {
+            match self
+                .try_single_target(agent, callee_state_rx, Some(Self::QUEUE_HOLD_TRACK_ID))
+                .await
+            {
                 Ok(()) => {
                     info!(index = idx, "Queue: agent connected");
                     return Ok(());
@@ -1567,7 +1703,8 @@ impl SipSession {
     ) -> Result<(), (StatusCode, Option<String>)> {
         if let Some(agent) = agents.first() {
             info!(agent = %agent.aor, "Queue: trying parallel agent");
-            self.try_single_target(agent, callee_state_rx).await
+            self.try_single_target(agent, callee_state_rx, Some(Self::QUEUE_HOLD_TRACK_ID))
+                .await
         } else {
             Err((
                 StatusCode::TemporarilyUnavailable,
@@ -1720,6 +1857,7 @@ impl SipSession {
         &mut self,
         target: &crate::call::Location,
         callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
+        stop_playback_on_answer: Option<&str>,
     ) -> Result<(), (StatusCode, Option<String>)> {
         use rsipstack::dialog::dialog::DialogState;
         use rsipstack::dialog::invitation::InviteOption;
@@ -1772,6 +1910,7 @@ impl SipSession {
         self.callee_is_webrtc = callee_is_webrtc;
 
         let callee_sdp = if self.bypasses_local_media() && caller_is_webrtc == callee_is_webrtc {
+            self.callee_offer_uses_media_bridge = false;
             self.caller_offer.clone()
         } else {
             self.create_callee_track(callee_is_webrtc).await.ok()
@@ -2010,6 +2149,9 @@ impl SipSession {
                 Some(String::from_utf8_lossy(body).to_string())
             }
         });
+        if let Some(track_id) = stop_playback_on_answer {
+            self.stop_playback_track(track_id, false).await;
+        }
         let caller_answer = self
             .prepare_caller_answer_from_callee_sdp(callee_sdp, false)
             .await;
@@ -2078,6 +2220,27 @@ impl SipSession {
                 session_id = %self.context.session_id,
                 "Callee answer SDP changed after early media; regenerating caller-facing SDP"
             );
+        }
+
+        if self.server_dialog.state().is_confirmed()
+            && self.answer.is_some()
+            && self.media_bridge.is_some()
+            && self.caller_answer_uses_media_bridge
+            && self.callee_offer_uses_media_bridge
+        {
+            match self.apply_bridge_callee_answer(&callee_sdp_value).await {
+                Ok(()) => self.start_media_bridge_forwarding().await,
+                Err(error) => {
+                    warn!(
+                        session_id = %self.context.session_id,
+                        error = %error,
+                        "Failed to apply callee answer to existing media bridge"
+                    );
+                }
+            }
+
+            self.callee_answer_sdp = Some(callee_sdp_value);
+            return self.answer.clone();
         }
 
         if self.server_dialog.state().is_confirmed()
@@ -2391,6 +2554,9 @@ impl SipSession {
 
         self.callee_answer_sdp = callee_sdp.clone();
         self.answer = caller_answer.clone();
+        self.caller_answer_uses_media_bridge = self.callee_offer_uses_media_bridge
+            && self.media_bridge.is_some()
+            && caller_answer.is_some();
 
         if self.media_profile.path == MediaPathMode::Anchored && self.media_bridge.is_none() {
             let caller_answer_for_forwarding = self.answer.clone();
@@ -2402,8 +2568,74 @@ impl SipSession {
             .await;
         }
 
+        if self.media_bridge.is_some() && self.caller_answer_uses_media_bridge {
+            self.start_media_bridge_forwarding().await;
+        }
+
         caller_answer
     }
+
+    async fn start_media_bridge_forwarding(&mut self) {
+        if self.media_bridge_started {
+            return;
+        }
+
+        if let Some(ref bridge) = self.media_bridge {
+            let caller_pc = if self.caller_is_webrtc {
+                bridge.webrtc_pc()
+            } else {
+                bridge.rtp_pc()
+            };
+            let callee_pc = if self.callee_is_webrtc {
+                bridge.webrtc_pc()
+            } else {
+                bridge.rtp_pc()
+            };
+
+            if caller_pc.local_description().is_none()
+                || caller_pc.remote_description().is_none()
+                || callee_pc.local_description().is_none()
+                || callee_pc.remote_description().is_none()
+            {
+                warn!(
+                    session_id = %self.context.session_id,
+                    caller_local = caller_pc.local_description().is_some(),
+                    caller_remote = caller_pc.remote_description().is_some(),
+                    callee_local = callee_pc.local_description().is_some(),
+                    callee_remote = callee_pc.remote_description().is_some(),
+                    "Media bridge forwarding not started because SDP is incomplete"
+                );
+                return;
+            }
+
+            bridge.replace_output_with_peer(self.caller_bridge_endpoint());
+            bridge.replace_output_with_peer(self.callee_bridge_endpoint());
+
+            info!(
+                session_id = %self.context.session_id,
+                "Starting media bridge forwarding"
+            );
+            bridge.start_bridge().await;
+            self.media_bridge_started = true;
+        }
+    }
+
+    fn caller_bridge_endpoint(&self) -> BridgeEndpoint {
+        if self.caller_is_webrtc {
+            BridgeEndpoint::WebRtc
+        } else {
+            BridgeEndpoint::Rtp
+        }
+    }
+
+    fn callee_bridge_endpoint(&self) -> BridgeEndpoint {
+        if self.callee_is_webrtc {
+            BridgeEndpoint::WebRtc
+        } else {
+            BridgeEndpoint::Rtp
+        }
+    }
+
     async fn start_anchored_media_forwarding(
         &mut self,
         caller_answer_sdp: Option<&str>,
@@ -2786,6 +3018,65 @@ impl SipSession {
         Ok(forwarding)
     }
 
+    async fn bridge_callee_offer_sdp(
+        bridge: &crate::media::bridge::BridgePeer,
+        callee_is_webrtc: bool,
+    ) -> Result<String> {
+        let pc = if callee_is_webrtc {
+            bridge.webrtc_pc().clone()
+        } else {
+            bridge.rtp_pc().clone()
+        };
+
+        if let Some(local_description) = pc.local_description() {
+            return Ok(local_description.to_sdp_string());
+        }
+
+        let offer = pc.create_offer().await?;
+        pc.set_local_description(offer)?;
+        if callee_is_webrtc {
+            pc.wait_for_gathering_complete().await;
+        }
+
+        pc.local_description()
+            .map(|desc| desc.to_sdp_string())
+            .ok_or_else(|| anyhow!("Bridge callee side has no local offer"))
+    }
+
+    async fn apply_bridge_callee_answer(&self, callee_sdp: &str) -> Result<()> {
+        let Some(bridge) = &self.media_bridge else {
+            return Ok(());
+        };
+
+        let pc = if self.callee_is_webrtc {
+            bridge.webrtc_pc().clone()
+        } else {
+            bridge.rtp_pc().clone()
+        };
+
+        if let Some(remote_description) = pc.remote_description() {
+            if remote_description.to_sdp_string() == callee_sdp {
+                return Ok(());
+            }
+
+            let offer = pc
+                .create_offer()
+                .await
+                .map_err(|e| anyhow!("Failed to create bridge callee re-offer: {}", e))?;
+            pc.set_local_description(offer)
+                .map_err(|e| anyhow!("Failed to set bridge callee local re-offer: {}", e))?;
+            if self.callee_is_webrtc {
+                pc.wait_for_gathering_complete().await;
+            }
+        }
+
+        let answer = rustrtc::SessionDescription::parse(rustrtc::SdpType::Answer, callee_sdp)
+            .map_err(|e| anyhow!("Failed to parse callee answer SDP: {}", e))?;
+        pc.set_remote_description(answer)
+            .await
+            .map_err(|e| anyhow!("Failed to set bridge callee remote answer: {}", e))
+    }
+
     pub async fn create_callee_track(&mut self, callee_is_webrtc: bool) -> Result<String> {
         let track_id = Self::CALLEE_TRACK_ID.to_string();
 
@@ -2806,7 +3097,21 @@ impl SipSession {
 
         let need_transport_bridge = transport_bridge_needed;
 
+        if need_transport_bridge
+            && self.caller_answer_uses_media_bridge
+            && let Some(ref bridge) = self.media_bridge
+        {
+            self.callee_offer_uses_media_bridge = true;
+            debug!(
+                session_id = %self.id,
+                callee_is_webrtc,
+                "Reusing existing media bridge callee-facing offer"
+            );
+            return Self::bridge_callee_offer_sdp(bridge, callee_is_webrtc).await;
+        }
+
         if need_transport_bridge {
+            self.callee_offer_uses_media_bridge = true;
             let mut bridge_builder = BridgePeerBuilder::new(format!("{}-bridge", self.id))
                 .with_enable_latching(self.server.proxy_config.enable_latching);
             if let (Some(start), Some(end)) = (
@@ -2990,8 +3295,6 @@ impl SipSession {
                 bridge.rtp_pc().set_local_description(offer)?;
             }
 
-            bridge.start_bridge().await;
-
             self.media_bridge = Some(bridge.clone());
 
             if callee_is_webrtc {
@@ -3010,6 +3313,7 @@ impl SipSession {
                 Ok(sdp)
             }
         } else if media_proxy_enabled {
+            self.callee_offer_uses_media_bridge = false;
             let mut track_builder = RtpTrackBuilder::new(track_id.clone())
                 .with_cancel_token(self.callee_peer.cancel_token())
                 .with_enable_latching(self.server.proxy_config.enable_latching);
@@ -3074,6 +3378,7 @@ impl SipSession {
 
             Ok(sdp)
         } else {
+            self.callee_offer_uses_media_bridge = false;
             let mut track_builder = RtpTrackBuilder::new(track_id.clone())
                 .with_cancel_token(self.callee_peer.cancel_token());
 
@@ -3098,6 +3403,7 @@ impl SipSession {
         if self.bypasses_local_media() {
             if let Some(answer_sdp) = self.callee_answer_sdp.clone() {
                 self.answer = Some(answer_sdp.clone());
+                self.caller_answer_uses_media_bridge = false;
                 return Some(answer_sdp);
             }
         }
@@ -3155,6 +3461,7 @@ impl SipSession {
                 );
                 self.caller_peer.update_track(Box::new(track), None).await;
                 self.answer = Some(answer_sdp.clone());
+                self.caller_answer_uses_media_bridge = false;
                 Some(answer_sdp)
             }
             Err(e) => {
@@ -3556,23 +3863,20 @@ impl SipSession {
             .with_loop(loop_playback)
             .with_codec_info(caller_codec);
 
-        // Use the RtcTrack's existing SampleStreamSource to inject audio frames
-        // without creating a new RTP sender (which would change SSRC and break
-        // audio in WebRTC/SRTP mode).
-        let sender = {
-            let mut sender = None;
-            for _ in 0..100 {
-                if let Some(found_sender) = self.get_caller_playback_sender().await {
-                    sender = Some(found_sender);
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
-            sender
-        };
-
-        if let Some(sender) = sender {
-            if let Err(e) = track.start_playback_on_sender(sender).await {
+        let mut uses_existing_caller_media = false;
+        if self.caller_answer_uses_media_bridge {
+            let bridge = self
+                .media_bridge
+                .as_ref()
+                .ok_or_else(|| anyhow!("No media bridge available for playback"))?;
+            bridge
+                .replace_output_with_file(self.caller_bridge_endpoint(), &track)
+                .await?;
+            self.bridge_playback_track_id = Some(track_id.to_string());
+            uses_existing_caller_media = true;
+        } else if let Some(pc) = self.get_caller_peer_connection().await {
+            uses_existing_caller_media = true;
+            if let Err(e) = track.start_playback_on(Some(pc)).await {
                 warn!(error = %e, "Failed to start playback");
             }
         } else {
@@ -3582,19 +3886,51 @@ impl SipSession {
             }
         }
 
+        if let Some(previous) = self.playback_tracks.remove(track_id) {
+            previous.stop().await;
+        }
+        self.playback_tracks
+            .insert(track_id.to_string(), track.clone());
+
         let wait_track = if await_completion && !loop_playback {
             Some(track.clone())
         } else {
             None
         };
 
-        self.caller_peer.update_track(Box::new(track), None).await;
+        if !uses_existing_caller_media {
+            self.caller_peer.update_track(Box::new(track), None).await;
+        }
 
         if let Some(track) = wait_track {
             track.wait_for_completion().await;
         }
 
         Ok(())
+    }
+
+    async fn stop_playback_track(&mut self, track_id: &str, remove_from_caller_peer: bool) {
+        let Some(track) = self.playback_tracks.remove(track_id) else {
+            return;
+        };
+
+        track.stop().await;
+        if self.bridge_playback_track_id.as_deref() == Some(track_id)
+            && self.caller_answer_uses_media_bridge
+            && let Some(ref bridge) = self.media_bridge
+        {
+            self.bridge_playback_track_id = None;
+            if self.media_bridge_started {
+                bridge.replace_output_with_peer(self.caller_bridge_endpoint());
+            } else {
+                bridge.mute_output(self.caller_bridge_endpoint());
+            }
+        }
+        if remove_from_caller_peer {
+            self.caller_peer.remove_track(track_id, true).await;
+        }
+
+        info!(track_id = %track_id, "Playback stopped");
     }
 
     fn resolve_audio_file_path(audio_file: &str) -> String {
@@ -3712,6 +4048,8 @@ impl SipSession {
         if let Some(bridge) = self.media_bridge.take() {
             info!(session_id = %self.context.session_id, "Stopping media bridge during cleanup");
             bridge.stop().await;
+            self.media_bridge_started = false;
+            self.bridge_playback_track_id = None;
         }
 
         // Stop caller and callee media peers (cancels their tasks)
@@ -5358,7 +5696,7 @@ impl SipSession {
             };
             let (_tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             return self
-                .try_single_target(&location, &mut rx)
+                .try_single_target(&location, &mut rx, None)
                 .await
                 .map_err(|(code, reason)| {
                     anyhow!(
@@ -6030,20 +6368,6 @@ impl SipSession {
         None
     }
 
-    /// Get the SampleStreamSource from the caller's RtcTrack for injecting
-    /// playback audio without creating a new RTP sender (which would change
-    /// SSRC and break audio in WebRTC/SRTP mode).
-    async fn get_caller_playback_sender(&self) -> Option<rustrtc::media::SampleStreamSource> {
-        let tracks = self.caller_peer.get_tracks().await;
-        for t in tracks.iter() {
-            let guard = t.lock().await;
-            if guard.id() == Self::CALLER_TRACK_ID {
-                return guard.get_sender();
-            }
-        }
-        None
-    }
-
     /// Create audio decoder based on negotiated codec from answer SDP.
     ///
     /// Extracts the codec from the caller's answer SDP and creates the appropriate decoder.
@@ -6660,31 +6984,28 @@ impl SipSession {
             .with_path(file_path.clone())
             .with_codec_info(caller_codec);
 
-        let sender = {
-            let mut sender = None;
-            for _ in 0..100 {
-                if let Some(found_sender) = self.get_caller_playback_sender().await {
-                    sender = Some(found_sender);
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
-            sender
-        };
-
-        if let Some(sender) = sender {
-            if let Err(e) = track.start_playback_on_sender(sender).await {
-                warn!(error = %e, "Failed to start playback");
-            }
+        let uses_bridge_output = if self.caller_answer_uses_media_bridge {
+            let bridge = self
+                .media_bridge
+                .as_ref()
+                .ok_or_else(|| anyhow!("No media bridge available for playback"))?;
+            bridge
+                .replace_output_with_file(self.caller_bridge_endpoint(), &track)
+                .await?;
+            self.bridge_playback_track_id = Some(track_id.clone());
+            true
         } else {
             if let Err(e) = track.start_playback_on(None).await {
                 warn!(error = %e, "Failed to start playback");
             }
-        }
+            false
+        };
 
-        self.caller_peer
-            .update_track(Box::new(track.clone()), None)
-            .await;
+        if !uses_bridge_output {
+            self.caller_peer
+                .update_track(Box::new(track.clone()), None)
+                .await;
+        }
         self.playback_tracks.insert(track_id.clone(), track.clone());
 
         info!(track_id = %track_id, file = %file_path, "Playback started");
@@ -6712,10 +7033,7 @@ impl SipSession {
         if leg_id.is_none() {
             let track_ids: Vec<String> = self.playback_tracks.keys().cloned().collect();
             for track_id in track_ids {
-                if self.playback_tracks.remove(&track_id).is_some() {
-                    self.caller_peer.remove_track(&track_id, true).await;
-                    info!(track_id = %track_id, "Playback stopped");
-                }
+                self.stop_playback_track(&track_id, true).await;
             }
             return Ok(());
         }
@@ -6725,10 +7043,7 @@ impl SipSession {
             .map(|l| l.to_string())
             .unwrap_or_else(|| "playback".to_string());
 
-        if self.playback_tracks.remove(&track_id).is_some() {
-            self.caller_peer.remove_track(&track_id, true).await;
-            info!(track_id = %track_id, "Playback stopped");
-        }
+        self.stop_playback_track(&track_id, true).await;
         Ok(())
     }
 
@@ -7856,7 +8171,7 @@ mod tests {
             .await
             .expect("queue hold audio should start");
 
-        assert_eq!(caller_peer.update_track_call_count(), 1);
+        assert_eq!(caller_peer.update_track_call_count(), 0);
         assert!(
             target_pc
                 .get_transceivers()


### PR DESCRIPTION
## Summary
- route queue early-answer and hold playback through the media bridge
- add bridge-owned silence/file output switching for caller media
- move bridge-backed RTP DTMF detection into the bridge receive loop so it does not compete with forwarding

## Validation
- cargo check

Additional focused tests were run before the final branch split/rebase:
- cargo test test_prepare_app_caller_media_bridge_routes_playback_through_bridge
- cargo test test_bridge_file_output_polls_file_track_source
- cargo test queue
