### PR TITLE
Stabilize JsSIP page instance id

### DIFF
--- a/static/phone_jssip.html
+++ b/static/phone_jssip.html
@@ -614,6 +614,13 @@
         let statsInterval = null;
         let ccWs = null;
         let sipMessageLog = [];
+        const pageInstanceId = (window.crypto && typeof window.crypto.randomUUID === 'function')
+            ? window.crypto.randomUUID()
+            : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+                const r = Math.random() * 16 | 0;
+                const v = c === 'x' ? r : (r & 0x3) | 0x8;
+                return v.toString(16);
+            });
 
         // ========== DOM Elements ==========
         const serverInput = document.getElementById('server');
@@ -1383,7 +1390,7 @@
             log('Attempting to register via JsSIP...');
 
             const socket = new JsSIP.WebSocketInterface(server);
-            const configuration = { sockets: [socket], uri: `sip:${username}@${domain}`, password: password, display_name: displayName || username, register: true };
+            const configuration = { sockets: [socket], uri: `sip:${username}@${domain}`, password: password, display_name: displayName || username, register: true, instance_id: pageInstanceId };
             try {
                 const pcConfig = getEnabledPcConfigFromUi();
                 if (pcConfig) { configuration.pcConfig = pcConfig; log(`Using custom ICE servers for UA: ${JSON.stringify(configuration.pcConfig)}`); }


### PR DESCRIPTION
## Summary
- Add a page-lifetime UUID for the JsSIP phone page.
- Pass that UUID as JsSIP `instance_id` so repeated registration from the same loaded page keeps the same `+sip.instance`.

## Why
JsSIP generates a new instance id whenever a new UA is created unless `instance_id` is provided. Reusing a page-lifetime id makes same-page re-registration identifiable without persisting identity across page refresh.

## Validation
- `node --check` on the embedded `phone_jssip.html` script body.
