### PR TITLE
Fix jsonrpc router default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ default = [
     "addon-transcript",
     "addon-archive",
     "addon-observability",
-    "addon-jsonrpc-router",
 ]
 cross = ["aws-lc-rs/bindgen"]
 perfcli-bin = []

--- a/src/handler/ami.rs
+++ b/src/handler/ami.rs
@@ -9,14 +9,11 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     middleware,
-    response::sse::{Event as SseEvent, KeepAlive, Sse},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
 use chrono::TimeZone;
-use futures::stream;
 use serde::Deserialize;
-use std::convert::Infallible;
 use std::sync::{Arc, atomic::Ordering};
 use tokio::time::{Duration, sleep};
 use tracing::{info, warn};
@@ -973,6 +970,10 @@ async fn cluster_reload_config_handler(
     State(state): State<AppState>,
     Query(query): Query<PingReloadPayload>,
 ) -> Response {
+    use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+    use futures::stream;
+    use std::convert::Infallible;
+
     let payload = query;
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<SseEvent, Infallible>>();
 

--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -2339,7 +2339,7 @@ mod tests {
         let (server, config) = create_test_server().await;
 
         // Register alice in the locator so she's online (BEFORE creating module)
-        server
+        let _ = server
             .locator
             .register(
                 "alice",

--- a/tests/helpers/test_server.rs
+++ b/tests/helpers/test_server.rs
@@ -76,6 +76,7 @@ impl TestPbx {
     /// Start a TestPbx bound to the given `sip_port`.
     ///
     /// Use `portpicker::pick_unused_port().unwrap()` to choose ports.
+    #[allow(dead_code)]
     pub async fn start(sip_port: u16) -> Self {
         Self::start_with_inject(sip_port, TestPbxInject::default()).await
     }

--- a/tests/ivr_queue_agent_audio_e2e_test.rs
+++ b/tests/ivr_queue_agent_audio_e2e_test.rs
@@ -82,6 +82,7 @@ fn rwi_req(action: &str, params: serde_json::Value) -> (String, String) {
     (id, json)
 }
 
+#[allow(dead_code)]
 async fn recv_until<F>(ws: &mut WsStream, timeout_ms: u64, predicate: F) -> serde_json::Value
 where
     F: Fn(&serde_json::Value) -> bool,

--- a/tests/ivr_queue_agent_e2e_test.rs
+++ b/tests/ivr_queue_agent_e2e_test.rs
@@ -71,6 +71,7 @@ async fn ws_send_recv(ws: &mut WsStream, json: &str) -> serde_json::Value {
     }
 }
 
+#[allow(dead_code)]
 async fn recv_until(
     ws: &mut WsStream,
     timeout_secs: u64,
@@ -118,7 +119,7 @@ async fn test_ivr_queue_agent_flow() {
     let _ = tracing_subscriber::fmt::try_init();
 
     let sip_port = portpicker::pick_unused_port().expect("no free SIP port");
-    let caller_port = portpicker::pick_unused_port().expect("no free caller port");
+    let _caller_port = portpicker::pick_unused_port().expect("no free caller port");
     let agent_port = portpicker::pick_unused_port().expect("no free agent port");
 
     // Start the PBX


### PR DESCRIPTION
## Summary
- remove `addon-jsonrpc-router` from default features because the repository only contains a symlink to private addon source
- move SSE-related AMI imports into the commerce-only handler where they are used

## Root cause
CI enables default features while building with `--features cross`. The default feature set included `addon-jsonrpc-router`, but `src/addons/jsonrpc_router` is a symlink to `../../../rustpbx-addons/jsonrpc_router`, so GitHub Actions cannot resolve `src/addons/jsonrpc_router/mod.rs`.

## Validation
- `cargo check`
- `cargo check --features cross`