### PR TITLE
Fix playback completion and cluster routing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ toml_edit = { version = "0.25.11", features = ["serde"] }
 rand = "0.10.1"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10.4"
-rsipstack = "0.5.9"
+rsipstack = "0.5.10"
 #rsipstack = { path = "../rsipstack" }
 audio-codec = { version = "=0.3.30", default-features = false }
 #rustrtc = { path = "../rustrtc" }

--- a/src/call/app/controller.rs
+++ b/src/call/app/controller.rs
@@ -186,7 +186,7 @@ impl CallController {
             source: MediaSource::File { path: path.clone() },
             options: Some(PlayOptions {
                 loop_playback,
-                await_completion: true,
+                await_completion: false,
                 interrupt_on_dtmf: interruptible,
                 track_id: Some(track_id.clone()),
                 send_progress: false,

--- a/src/call/app/event_loop.rs
+++ b/src/call/app/event_loop.rs
@@ -96,8 +96,12 @@ impl AppEventLoop {
                     Some(ControllerEvent::DtmfReceived(digit)) => {
                         self.app.on_dtmf(digit, &mut self.controller, &self.context).await
                     }
-                    Some(ControllerEvent::AudioComplete { track_id, .. }) => {
-                        self.app.on_audio_complete(track_id, &mut self.controller, &self.context).await
+                    Some(ControllerEvent::AudioComplete { track_id, interrupted }) => {
+                        if interrupted {
+                            Ok(AppAction::Continue)
+                        } else {
+                            self.app.on_audio_complete(track_id, &mut self.controller, &self.context).await
+                        }
                     }
                     Some(ControllerEvent::RecordingComplete(info)) => {
                         self.app.on_record_complete(info, &mut self.controller, &self.context).await

--- a/src/call/app/ivr_test.rs
+++ b/src/call/app/ivr_test.rs
@@ -1798,8 +1798,8 @@ action = { type = "transfer", target = "100" }
         path.to_string_lossy().to_string()
     }
 
-    /// Start real FileTrack playback for a PlayPrompt command and wire its
-    /// completion back into the MockCallStack event channel.
+    /// Start real FileTrack playback for a PlayPrompt command and emit its
+    /// completion into the MockCallStack event channel.
     ///
     /// Returns the FileTrack handle (for later stop/inspection if needed).
     async fn wire_real_playback(
@@ -1807,26 +1807,23 @@ action = { type = "transfer", target = "100" }
         stack: &MockCallStack,
     ) -> crate::media::FileTrack {
         use crate::call::app::ControllerEvent;
-        use crate::media::FileTrack;
+        use crate::media::{FileTrack, PlaybackEndReason};
         use audio_codec::CodecType;
 
+        let tx = stack.event_sender();
         let track = FileTrack::new("e2e-track".to_string())
             .with_path(audio_file.to_string())
             .with_loop(false)
-            .with_codec_preference(vec![CodecType::PCMU]);
+            .with_codec_preference(vec![CodecType::PCMU])
+            .with_on_end(std::sync::Arc::new(move |reason| {
+                let _ = tx.send(ControllerEvent::AudioComplete {
+                    track_id: "default".to_string(),
+                    interrupted: matches!(reason, PlaybackEndReason::Interrupted),
+                });
+            }));
 
         let _ = track.local_description().await;
         track.start_playback().await.expect("start_playback");
-
-        let tx = stack.event_sender();
-        let t = track.clone();
-        crate::utils::spawn(async move {
-            t.wait_for_completion().await;
-            let _ = tx.send(ControllerEvent::AudioComplete {
-                track_id: "default".to_string(),
-                interrupted: false,
-            });
-        });
 
         track
     }
@@ -1858,11 +1855,11 @@ action = { type = "transfer", target = "100" }
     // ── E2E: real FileTrack completion drives IVR AudioComplete ──────────────
 
     /// End-to-end integration test: a real `FileTrack` playing a real WAV file
-    /// fires `completion_notify` which is bridged to `MockCallStack::audio_complete()`
+    /// fires on_end, which emits `MockCallStack::audio_complete()`
     /// — verifying the full pipeline:
     ///
     ///   IVR emits PlayPrompt → FileTrack starts playback → WAV exhausted →
-    ///   completion_notify → AudioComplete injected → IVR advances state
+    ///   on_end → AudioComplete injected → IVR advances state
     #[tokio::test]
     async fn test_ivr_real_file_playback_drives_audio_complete() {
         use tokio::fs;

--- a/src/media/bridge.rs
+++ b/src/media/bridge.rs
@@ -713,12 +713,14 @@ impl BridgePeer {
 
         let source = track.create_playback_source()?;
         let mut state = self.output_state(endpoint).lock().await;
-        state.file_source = Some(source);
+        let old_source = state.file_source.replace(source);
         state.mode = BRIDGE_OUTPUT_FILE;
         state.active_rtp_offset = None;
         state.active_seq_offset = None;
         self.output_mode(endpoint)
             .store(BRIDGE_OUTPUT_FILE, Ordering::Release);
+        drop(state);
+        drop(old_source);
 
         info!(
             bridge_id = %self.id,
@@ -744,12 +746,14 @@ impl BridgePeer {
             .with_codec_info(codec_info);
         let source = track.create_playback_source()?;
         let mut state = self.output_state(endpoint).lock().await;
-        state.file_source = Some(source);
+        let old_source = state.file_source.replace(source);
         state.mode = BRIDGE_OUTPUT_FILE;
         state.active_rtp_offset = None;
         state.active_seq_offset = None;
         self.output_mode(endpoint)
             .store(BRIDGE_OUTPUT_FILE, Ordering::Release);
+        drop(state);
+        drop(old_source);
 
         info!(
             bridge_id = %self.id,
@@ -762,9 +766,11 @@ impl BridgePeer {
     pub async fn replace_output_with_peer(&self, endpoint: BridgeEndpoint) {
         let mut state = self.output_state(endpoint).lock().await;
         state.mode = BRIDGE_OUTPUT_PEER;
-        state.file_source = None;
+        let old_source = state.file_source.take();
         self.output_mode(endpoint)
             .store(BRIDGE_OUTPUT_PEER, Ordering::Release);
+        drop(state);
+        drop(old_source);
         info!(
             bridge_id = %self.id,
             endpoint = ?endpoint,
@@ -775,8 +781,11 @@ impl BridgePeer {
     pub async fn mute_output(&self, endpoint: BridgeEndpoint) {
         let mut state = self.output_state(endpoint).lock().await;
         state.mode = BRIDGE_OUTPUT_MUTED;
+        let old_source = state.file_source.take();
         self.output_mode(endpoint)
             .store(BRIDGE_OUTPUT_MUTED, Ordering::Release);
+        drop(state);
+        drop(old_source);
         info!(
             bridge_id = %self.id,
             endpoint = ?endpoint,

--- a/src/media/file_track_tests.rs
+++ b/src/media/file_track_tests.rs
@@ -179,7 +179,7 @@ async fn test_file_track_playback_starts() {
 
 // ── real playback completion (file-exhausted path) ────────────────────────────
 
-/// A short WAV file (160 samples = 20 ms at 8 kHz) must fire completion_notify
+/// A short WAV file (160 samples = 20 ms at 8 kHz) must fire on_end
 /// within a reasonable time once start_playback() is called.
 #[tokio::test]
 async fn test_file_track_playback_completion_accurate() {
@@ -190,10 +190,14 @@ async fn test_file_track_playback_completion_accurate() {
         .await
         .unwrap();
 
+    let (end_tx, mut end_rx) = tokio::sync::mpsc::unbounded_channel();
     let track = FileTrack::new("completion-accurate".to_string())
         .with_path(test_file.to_string_lossy().to_string())
         .with_loop(false)
-        .with_codec_preference(vec![CodecType::PCMU]);
+        .with_codec_preference(vec![CodecType::PCMU])
+        .with_on_end(std::sync::Arc::new(move |reason| {
+            let _ = end_tx.send(reason);
+        }));
 
     let _ = track.local_description().await;
     track.start_playback().await.unwrap();
@@ -202,13 +206,13 @@ async fn test_file_track_playback_completion_accurate() {
     // fires every 20 ms, so it should finish in ≤ 40 ms in practice).
     let result = tokio::time::timeout(
         tokio::time::Duration::from_secs(2),
-        track.wait_for_completion(),
+        end_rx.recv(),
     )
     .await;
 
     assert!(
-        result.is_ok(),
-        "Playback completion notify must fire when the file is exhausted (not after a fixed sleep)"
+        matches!(result, Ok(Some(PlaybackEndReason::Completed))),
+        "Playback on_end must fire Completed when the file is exhausted (not after a fixed sleep)"
     );
 
     let _ = fs::remove_file(&test_file).await;
@@ -223,9 +227,13 @@ async fn test_file_track_playback_completion() {
         .await
         .unwrap();
 
+    let (end_tx, mut end_rx) = tokio::sync::mpsc::unbounded_channel();
     let track = FileTrack::new("completion-test".to_string())
         .with_path(test_file.to_string_lossy().to_string())
-        .with_loop(false);
+        .with_loop(false)
+        .with_on_end(std::sync::Arc::new(move |reason| {
+            let _ = end_tx.send(reason);
+        }));
 
     let _ = track.local_description().await;
     track.start_playback().await.unwrap();
@@ -234,18 +242,21 @@ async fn test_file_track_playback_completion() {
     // immediately returns 0, triggering completion.
     let completion = tokio::time::timeout(
         tokio::time::Duration::from_millis(500),
-        track.wait_for_completion(),
+        end_rx.recv(),
     )
     .await;
 
-    assert!(completion.is_ok(), "Playback should complete");
+    assert!(
+        matches!(completion, Ok(Some(PlaybackEndReason::Completed))),
+        "Playback should complete"
+    );
 
     let _ = fs::remove_file(&test_file).await;
 }
 
 // ── cancel stops playback ─────────────────────────────────────────────────────
 
-/// Cancelling a looping track via stop() must fire completion_notify quickly.
+/// Cancelling a looping track via stop() must fire on_end quickly.
 #[tokio::test]
 async fn test_file_track_cancel_stops_rtp() {
     let temp_dir = std::env::temp_dir();
@@ -256,11 +267,15 @@ async fn test_file_track_cancel_stops_rtp() {
         .unwrap();
 
     let cancel_token = CancellationToken::new();
+    let (end_tx, mut end_rx) = tokio::sync::mpsc::unbounded_channel();
     let track = FileTrack::new("cancel-rtp".to_string())
         .with_path(test_file.to_string_lossy().to_string())
         .with_loop(true) // loop forever unless stopped
         .with_cancel_token(cancel_token.clone())
-        .with_codec_preference(vec![CodecType::PCMU]);
+        .with_codec_preference(vec![CodecType::PCMU])
+        .with_on_end(std::sync::Arc::new(move |reason| {
+            let _ = end_tx.send(reason);
+        }));
 
     let _ = track.local_description().await;
     track.start_playback().await.unwrap();
@@ -269,16 +284,16 @@ async fn test_file_track_cancel_stops_rtp() {
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
     track.stop().await;
 
-    // completion_notify must fire promptly after cancellation.
+    // on_end must fire promptly after cancellation.
     let result = tokio::time::timeout(
         tokio::time::Duration::from_millis(500),
-        track.wait_for_completion(),
+        end_rx.recv(),
     )
     .await;
 
     assert!(
-        result.is_ok(),
-        "completion_notify must fire after stop() cancels the playback task"
+        matches!(result, Ok(Some(PlaybackEndReason::Interrupted))),
+        "on_end must fire Interrupted after stop() cancels the playback task"
     );
 
     let _ = fs::remove_file(&test_file).await;
@@ -349,12 +364,11 @@ a=rtpmap:0 PCMU/8000
 
 // ── e2e: FileTrack completion drives AudioComplete event ─────────────────────
 
-/// End-to-end test: verify that a real `FileTrack` playback completion fires
-/// `completion_notify`, which can be wired to a `ControllerEvent::AudioComplete`
-/// channel — the exact pipeline used by `play_audio_file()` in the session layer.
+/// End-to-end test: verify that a real `FileTrack` playback completion can fire
+/// the `ControllerEvent::AudioComplete` event through its on_end callback.
 ///
 /// This test exercises:
-///   WAV file → AudioSourceManager → RTP loop → completion_notify → channel event
+///   WAV file → AudioSourceManager → RTP loop → on_end → channel event
 ///
 /// Without this test, only the stub behaviour (sleep 100ms) was covered.
 #[tokio::test]
@@ -369,37 +383,20 @@ async fn test_file_track_completion_drives_audio_complete_event() {
         .await
         .unwrap();
 
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<ControllerEvent>();
     let track = FileTrack::new("e2e-audio-complete".to_string())
         .with_path(test_file.to_string_lossy().to_string())
         .with_loop(false)
-        .with_codec_preference(vec![CodecType::PCMU]);
+        .with_codec_preference(vec![CodecType::PCMU])
+        .with_on_end(std::sync::Arc::new(move |reason| {
+            let _ = event_tx.send(ControllerEvent::AudioComplete {
+                track_id: "default".to_string(),
+                interrupted: matches!(reason, PlaybackEndReason::Interrupted),
+            });
+        }));
 
     let _ = track.local_description().await;
     track.start_playback().await.unwrap();
-
-    // Wire completion_notify → ControllerEvent channel (mirrors play_audio_file()).
-    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<ControllerEvent>();
-    let completion_notify = track.completion_notify.clone();
-    let cancel = CancellationToken::new();
-    let cancel_child = cancel.child_token();
-    let fp = test_file.to_string_lossy().to_string();
-    crate::utils::spawn(async move {
-        tokio::select! {
-            _ = completion_notify.notified() => {
-                let _ = event_tx.send(ControllerEvent::AudioComplete {
-                    track_id: "default".to_string(),
-                    interrupted: false,
-                });
-            }
-            _ = cancel_child.cancelled() => {
-                let _ = event_tx.send(ControllerEvent::AudioComplete {
-                    track_id: "default".to_string(),
-                    interrupted: true,
-                });
-            }
-        }
-        drop(fp);
-    });
 
     // Allow 2 s — the 20 ms file should complete within ~40 ms.
     let event = tokio::time::timeout(tokio::time::Duration::from_secs(2), event_rx.recv())
@@ -421,7 +418,6 @@ async fn test_file_track_completion_drives_audio_complete_event() {
         other => panic!("unexpected event: {:?}", other),
     }
 
-    cancel.cancel();
     let _ = fs::remove_file(&test_file).await;
 }
 
@@ -440,57 +436,44 @@ async fn test_file_track_stop_drives_interrupted_audio_complete() {
         .await
         .unwrap();
 
+    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<ControllerEvent>();
     let cancel_token = CancellationToken::new();
     let track = FileTrack::new("e2e-interrupted".to_string())
         .with_path(test_file.to_string_lossy().to_string())
         .with_loop(true)
         .with_cancel_token(cancel_token.clone())
-        .with_codec_preference(vec![CodecType::PCMU]);
+        .with_codec_preference(vec![CodecType::PCMU])
+        .with_on_end(std::sync::Arc::new(move |reason| {
+            let _ = event_tx.send(ControllerEvent::AudioComplete {
+                track_id: "default".to_string(),
+                interrupted: matches!(reason, PlaybackEndReason::Interrupted),
+            });
+        }));
 
     let _ = track.local_description().await;
     track.start_playback().await.unwrap();
-
-    // Wire completion_notify → channel (mirrors play_audio_file()).
-    let (event_tx, mut event_rx) = mpsc::unbounded_channel::<ControllerEvent>();
-    let completion_notify = track.completion_notify.clone();
-    let session_cancel = CancellationToken::new();
-    let session_child = session_cancel.child_token();
-    crate::utils::spawn(async move {
-        tokio::select! {
-            _ = completion_notify.notified() => {
-                // File exhausted or track stopped — send non-interrupted.
-                let _ = event_tx.send(ControllerEvent::AudioComplete {
-                    track_id: "default".to_string(),
-                    interrupted: false,
-                });
-            }
-            _ = session_child.cancelled() => {
-                let _ = event_tx.send(ControllerEvent::AudioComplete {
-                    track_id: "default".to_string(),
-                    interrupted: true,
-                });
-            }
-        }
-    });
 
     // Let it play a few frames, then stop the track (simulates session teardown).
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
     track.stop().await;
 
-    // completion_notify fires → watcher sends AudioComplete (interrupted=false
-    // in this wiring, since we chose notify over session cancel).
     let event = tokio::time::timeout(tokio::time::Duration::from_millis(500), event_rx.recv())
         .await
         .expect("AudioComplete must arrive within 500 ms after stop()")
         .expect("channel must not be closed");
 
     assert!(
-        matches!(event, ControllerEvent::AudioComplete { .. }),
-        "Expected AudioComplete after stop(), got: {:?}",
+        matches!(
+            event,
+            ControllerEvent::AudioComplete {
+                interrupted: true,
+                ..
+            }
+        ),
+        "Expected interrupted AudioComplete after stop(), got: {:?}",
         event
     );
 
-    session_cancel.cancel();
     let _ = fs::remove_file(&test_file).await;
 }
 
@@ -670,7 +653,7 @@ async fn test_start_playback_on_external_pc_delivers_rtp() {
 }
 
 /// Verify that `start_playback_on(None)` still works (backward compatibility) —
-/// frames go into the FileTrack's own PC; completion_notify still fires.
+/// frames go into the FileTrack's own PC; on_end still fires.
 #[tokio::test]
 async fn test_start_playback_on_none_backward_compatible() {
     let temp_dir = std::env::temp_dir();
@@ -679,10 +662,14 @@ async fn test_start_playback_on_none_backward_compatible() {
         .await
         .unwrap();
 
+    let (end_tx, mut end_rx) = tokio::sync::mpsc::unbounded_channel();
     let track = FileTrack::new("compat-test".to_string())
         .with_path(test_file.to_string_lossy().to_string())
         .with_loop(false)
-        .with_codec_preference(vec![CodecType::PCMU]);
+        .with_codec_preference(vec![CodecType::PCMU])
+        .with_on_end(std::sync::Arc::new(move |reason| {
+            let _ = end_tx.send(reason);
+        }));
 
     let _ = track.local_description().await;
 
@@ -692,13 +679,13 @@ async fn test_start_playback_on_none_backward_compatible() {
 
     let result = tokio::time::timeout(
         tokio::time::Duration::from_secs(2),
-        track.wait_for_completion(),
+        end_rx.recv(),
     )
     .await;
 
     assert!(
-        result.is_ok(),
-        "start_playback_on(None) must fire completion_notify just like start_playback()"
+        matches!(result, Ok(Some(PlaybackEndReason::Completed))),
+        "start_playback_on(None) must fire on_end just like start_playback()"
     );
 
     let _ = fs::remove_file(&test_file).await;

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -654,7 +654,7 @@ pub struct FileTrack {
     loop_playback: bool,
     cancel_token: CancellationToken,
     pc: PeerConnection,
-    completion_notify: Arc<tokio::sync::Notify>,
+    on_end: Option<PlaybackEndCallback>,
     codec_preference: Vec<CodecType>,
     codec_info: Option<negotiate::CodecInfo>,
     mode: TransportMode,
@@ -675,7 +675,7 @@ impl Clone for FileTrack {
             loop_playback: self.loop_playback,
             cancel_token: self.cancel_token.clone(),
             pc: self.pc.clone(),
-            completion_notify: self.completion_notify.clone(),
+            on_end: self.on_end.clone(),
             codec_preference: self.codec_preference.clone(),
             codec_info: self.codec_info.clone(),
             mode: self.mode.clone(),
@@ -700,7 +700,7 @@ pub(crate) struct FileTrackPlaybackSource {
     rtp_ticks_per_frame: u32,
     rtp_timestamp: u32,
     sequence_number: u16,
-    completion_notify: Arc<tokio::sync::Notify>,
+    on_end: Option<PlaybackEndCallback>,
     loop_playback: bool,
 }
 
@@ -715,7 +715,9 @@ impl FileTrackPlaybackSource {
 
         if read == 0 {
             debug!("FileTrack playback completed (source exhausted)");
-            self.completion_notify.notify_waiters();
+            if let Some(on_end) = self.on_end.take() {
+                on_end(PlaybackEndReason::Completed);
+            }
             return None;
         }
 
@@ -739,6 +741,22 @@ impl FileTrackPlaybackSource {
     }
 }
 
+impl Drop for FileTrackPlaybackSource {
+    fn drop(&mut self) {
+        if let Some(on_end) = self.on_end.take() {
+            on_end(PlaybackEndReason::Interrupted);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaybackEndReason {
+    Completed,
+    Interrupted,
+}
+
+pub type PlaybackEndCallback = Arc<dyn Fn(PlaybackEndReason) + Send + Sync + 'static>;
+
 impl FileTrack {
     pub fn new(track_id: String) -> Self {
         let config = RtcConfiguration {
@@ -755,7 +773,7 @@ impl FileTrack {
             loop_playback: false,
             cancel_token: CancellationToken::new(),
             pc,
-            completion_notify: Arc::new(tokio::sync::Notify::new()),
+            on_end: None,
             codec_preference: vec![CodecType::PCMU, CodecType::PCMA],
             codec_info: None,
             mode: TransportMode::Rtp,
@@ -781,6 +799,11 @@ impl FileTrack {
 
     pub fn with_cancel_token(mut self, token: CancellationToken) -> Self {
         self.cancel_token = token;
+        self
+    }
+
+    pub fn with_on_end(mut self, on_end: PlaybackEndCallback) -> Self {
+        self.on_end = Some(on_end);
         self
     }
 
@@ -843,10 +866,6 @@ impl FileTrack {
 
     pub fn with_ssrc(self, _ssrc: u32) -> Self {
         self
-    }
-
-    pub async fn wait_for_completion(&self) {
-        self.completion_notify.notified().await;
     }
 
     fn init_audio_source(&mut self) -> Result<()> {
@@ -934,7 +953,7 @@ impl FileTrack {
             rtp_ticks_per_frame: frame_timing.rtp_ticks_per_frame,
             rtp_timestamp: rand::random(),
             sequence_number: rand::random(),
-            completion_notify: self.completion_notify.clone(),
+            on_end: self.on_end.clone(),
             loop_playback: self.loop_playback,
         })
     }
@@ -1028,7 +1047,7 @@ impl FileTrack {
         }
 
         // Clone everything we need to move into the background task.
-        let completion_notify = self.completion_notify.clone();
+        let mut on_end = self.on_end.clone();
         let cancel_token = self.cancel_token.clone();
         let loop_playback = self.loop_playback;
 
@@ -1044,7 +1063,9 @@ impl FileTrack {
                 tokio::select! {
                     _ = cancel_token.cancelled() => {
                         debug!("FileTrack playback cancelled");
-                        completion_notify.notify_waiters();
+                        if let Some(on_end) = on_end.take() {
+                            on_end(PlaybackEndReason::Interrupted);
+                        }
                         break;
                     }
                     _ = interval.tick() => {
@@ -1053,13 +1074,11 @@ impl FileTrack {
                         let read = audio_source_manager.read_samples(&mut pcm_buf);
 
                         if read == 0 {
-                            // Source exhausted — completion_notify was already
-                            // triggered by AudioSourceManager::read_samples.
-                            // For non-looping sources we also notify here in case
-                            // the manager chose not to.
                             if !loop_playback {
                                 debug!("FileTrack playback completed (file exhausted)");
-                                completion_notify.notify_waiters();
+                                if let Some(on_end) = on_end.take() {
+                                    on_end(PlaybackEndReason::Completed);
+                                }
                                 break;
                             }
                             // Looping sources restart automatically; keep going.
@@ -1087,7 +1106,9 @@ impl FileTrack {
 
                         if let Err(e) = source_target.send(MediaSample::Audio(frame)).await {
                             debug!("FileTrack source_target.send failed (receiver gone): {}", e);
-                            completion_notify.notify_waiters();
+                            if let Some(on_end) = on_end.take() {
+                                on_end(PlaybackEndReason::Interrupted);
+                            }
                             break;
                         }
                     }
@@ -1186,7 +1207,6 @@ impl Track for FileTrack {
 
     async fn stop(&self) {
         self.cancel_token.cancel();
-        self.completion_notify.notify_waiters();
     }
 
     async fn get_peer_connection(&self) -> Option<PeerConnection> {

--- a/src/proxy/auth.rs
+++ b/src/proxy/auth.rs
@@ -15,7 +15,7 @@ use rsipstack::sip::headers::{ProxyAuthenticate, WwwAuthenticate};
 use rsipstack::sip::prelude::{HeadersExt, ToTypedHeader};
 use rsipstack::sip::typed::Authorization;
 use rsipstack::transaction::transaction::Transaction;
-use rsipstack::transport::{SipAddr, SipConnection};
+use rsipstack::transport::SipAddr;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -189,15 +189,9 @@ impl AuthModule {
 
     /// Get the source address from the transaction
     fn get_source_addr(&self, tx: &Transaction) -> Option<SipAddr> {
-        tx.original
-            .via_header()
-            .ok()
-            .and_then(|via| SipConnection::parse_target_from_via(via).ok())
-            .map(|(transport, addr)| SipAddr {
-                r#type: Some(transport),
-                addr,
-            })
-            .or_else(|| tx.connection.as_ref().map(|conn| conn.get_addr().clone()))
+        tx.connection
+            .as_ref()
+            .and_then(|conn| conn.get_remote_addr().cloned())
     }
 
     /// Extract cache key (call_id, from_tag) from a transaction.

--- a/src/proxy/auth.rs
+++ b/src/proxy/auth.rs
@@ -15,6 +15,7 @@ use rsipstack::sip::headers::{ProxyAuthenticate, WwwAuthenticate};
 use rsipstack::sip::prelude::{HeadersExt, ToTypedHeader};
 use rsipstack::sip::typed::Authorization;
 use rsipstack::transaction::transaction::Transaction;
+use rsipstack::transport::{SipAddr, SipConnection};
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -187,8 +188,16 @@ impl AuthModule {
     }
 
     /// Get the source address from the transaction
-    fn get_source_addr(&self, tx: &Transaction) -> Option<rsipstack::transport::SipAddr> {
-        tx.connection.as_ref().map(|conn| conn.get_addr().clone())
+    fn get_source_addr(&self, tx: &Transaction) -> Option<SipAddr> {
+        tx.original
+            .via_header()
+            .ok()
+            .and_then(|via| SipConnection::parse_target_from_via(via).ok())
+            .map(|(transport, addr)| SipAddr {
+                r#type: Some(transport),
+                addr,
+            })
+            .or_else(|| tx.connection.as_ref().map(|conn| conn.get_addr().clone()))
     }
 
     /// Extract cache key (call_id, from_tag) from a transaction.

--- a/src/proxy/cluster_event.rs
+++ b/src/proxy/cluster_event.rs
@@ -17,7 +17,7 @@ use rsipstack::sip::Param;
 use rsipstack::sip::headers::typed::CSeq;
 use rsipstack::sip::headers::{CallId, ContentType};
 use rsipstack::sip::typed::{From as FromHeader, To as ToHeader, Via};
-use rsipstack::sip::{Header, Method, Request, Uri, Version};
+use rsipstack::sip::{Header, Method, Request, SipMessage, Uri, Version};
 use rsipstack::transaction::endpoint::EndpointInnerRef;
 use rsipstack::transaction::key::{TransactionKey, TransactionRole};
 use rsipstack::transaction::transaction::Transaction;
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -179,6 +180,7 @@ pub struct ClusterEventHub {
     locator_events: tokio::sync::broadcast::Sender<LocatorEvent>,
     presence_manager: Arc<PresenceManager>,
     endpoint_inner: EndpointInnerRef,
+    local_sip_addr: SocketAddr,
     peers: Vec<SocketAddr>,
     handlers: RwLock<Vec<Arc<dyn ClusterEventHandler>>>,
 }
@@ -188,12 +190,14 @@ impl ClusterEventHub {
         locator_events: tokio::sync::broadcast::Sender<LocatorEvent>,
         presence_manager: Arc<PresenceManager>,
         endpoint_inner: EndpointInnerRef,
+        local_sip_addr: SocketAddr,
         peers: Vec<SocketAddr>,
     ) -> Self {
         Self {
             locator_events,
             presence_manager,
             endpoint_inner,
+            local_sip_addr,
             peers,
             handlers: RwLock::new(Vec::new()),
         }
@@ -349,11 +353,14 @@ impl ClusterEventHub {
             .unwrap_or("tag")
             .to_string();
 
-        let via = Via::parse(&format!("SIP/2.0/UDP {}:5060;branch={}", peer.ip(), branch))
-            .map_err(|e| anyhow!("invalid via: {}", e))?;
+        let via = Via::parse(&format!(
+            "SIP/2.0/UDP {};branch={}",
+            self.local_sip_addr, branch
+        ))
+        .map_err(|e| anyhow!("invalid via: {}", e))?;
         let from = FromHeader {
             display_name: None,
-            uri: format!("sip:cluster@{}", peer.ip()).parse()?,
+            uri: format!("sip:cluster@{}", self.local_sip_addr).parse()?,
             params: vec![Param::Tag(rsipstack::sip::uri::Tag::new(&tag))],
         };
         let to = ToHeader {
@@ -387,6 +394,13 @@ impl ClusterEventHub {
         let mut tx = Transaction::new_client(key, request, self.endpoint_inner.clone(), None);
         tx.send().await?;
         debug!("cluster MESSAGE sent to {}", peer);
+        match tokio::time::timeout(Duration::from_millis(200), tx.receive()).await {
+            Ok(Some(SipMessage::Response(resp))) => {
+                debug!(status = %resp.status_code, peer = %peer, "cluster MESSAGE response received");
+            }
+            Ok(_) => {}
+            Err(_) => debug!("timed out waiting for cluster MESSAGE response from {}", peer),
+        }
         Ok(())
     }
 }
@@ -414,7 +428,7 @@ impl ClusterEventModule {
     }
 
     fn extract_source_ip(tx: &Transaction) -> Option<IpAddr> {
-        let addr = tx.connection.as_ref()?.get_addr();
+        let addr = tx.connection.as_ref()?.get_remote_addr()?;
         let ip: IpAddr = addr.addr.host.clone().try_into().ok()?;
         Some(ip)
     }
@@ -990,6 +1004,7 @@ mod tests {
             locator_tx,
             presence_manager,
             endpoint.inner.clone(),
+            "127.0.0.1:5060".parse().unwrap(),
             vec![],
         ))
     }

--- a/src/proxy/locator.rs
+++ b/src/proxy/locator.rs
@@ -97,26 +97,36 @@ impl DialogTargetLocator {
 impl TargetLocator for DialogTargetLocator {
     async fn locate(&self, uri: &rsipstack::sip::Uri) -> Result<SipAddr, rsipstack::Error> {
         if let Ok(locs) = self.locator.lookup(uri).await
-            && let Some(loc) = locs.first()
+            && !locs.is_empty()
         {
-            if self.cluster_enabled
-                && loc.registered_aor.as_ref() == Some(uri)
-                && let Some(home_proxy) = &loc.home_proxy
-            {
-                if self.is_local_home_proxy(home_proxy)
-                    && let Some(dest) = &loc.destination
-                {
-                    debug!(%uri, %dest, %home_proxy, "Located local registered AOR target via destination");
-                    return Ok(dest.clone());
-                }
+            if let Some(loc) = locs.iter().find(|loc| {
+                self.cluster_enabled
+                    && loc.home_proxy.as_ref().is_some_and(|home_proxy| {
+                        loc.registered_aor.as_ref().is_some_and(|registered_aor| {
+                            registered_aor == uri
+                                || (registered_aor.user() == uri.user()
+                                    && uri.host_with_port == home_proxy.addr)
+                        })
+                    })
+            }) {
+                if let Some(home_proxy) = &loc.home_proxy {
+                    if self.is_local_home_proxy(home_proxy)
+                        && let Some(dest) = &loc.destination
+                    {
+                        debug!(%uri, %dest, %home_proxy, "Located local registered AOR target via destination");
+                        return Ok(dest.clone());
+                    }
 
-                debug!(%uri, dest = %home_proxy, "Located registered AOR target via home proxy");
-                return Ok(home_proxy.clone());
+                    debug!(%uri, dest = %home_proxy, "Located registered AOR target via home proxy");
+                    return Ok(home_proxy.clone());
+                }
             }
 
-            if let Some(dest) = &loc.destination {
-                debug!(%uri, %dest, "Located target for dialog");
-                return Ok(dest.clone());
+            if let Some(loc) = locs.first() {
+                if let Some(dest) = &loc.destination {
+                    debug!(%uri, %dest, "Located target for dialog");
+                    return Ok(dest.clone());
+                }
             }
         }
         SipAddr::try_from(uri).map_err(|e| {
@@ -726,7 +736,8 @@ mod tests {
     #[tokio::test]
     async fn dialog_target_locator_routes_registered_aor_via_home_proxy() {
         let locator = MemoryLocator::new();
-        let uri: rsipstack::sip::Uri = "sip:alice@rustpbx.com".try_into().unwrap();
+        let registered_aor: rsipstack::sip::Uri = "sip:alice@10.0.0.1".try_into().unwrap();
+        let target_uri: rsipstack::sip::Uri = "sip:alice@10.0.0.1:5060".try_into().unwrap();
 
         let destination = SipAddr {
             r#type: Some(Transport::Udp),
@@ -741,13 +752,13 @@ mod tests {
         locator
             .register(
                 "alice",
-                Some("rustpbx.com"),
+                Some("10.0.0.1"),
                 Location {
-                    aor: uri.clone(),
+                    aor: registered_aor.clone(),
                     expires: 3600,
                     destination: Some(destination.clone()),
                     home_proxy: Some(home_proxy.clone()),
-                    registered_aor: Some(uri.clone()),
+                    registered_aor: Some(registered_aor),
                     last_modified: Some(Instant::now()),
                     ..Default::default()
                 },
@@ -756,7 +767,7 @@ mod tests {
             .unwrap();
 
         let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![], true);
-        let result = target_locator.locate(&uri).await.unwrap();
+        let result = target_locator.locate(&target_uri).await.unwrap();
         assert_eq!(
             result, home_proxy,
             "DialogTargetLocator should route registered AOR via home_proxy"

--- a/src/proxy/locator.rs
+++ b/src/proxy/locator.rs
@@ -160,7 +160,8 @@ impl TransportInspectorLocator {
 impl TransportEventInspector for TransportInspectorLocator {
     async fn handle(&self, event: TransportEvent) -> Option<TransportEvent> {
         if let TransportEvent::Closed(conn) = &event {
-            match self.locator.unregister_with_address(conn.get_addr()).await {
+            let addr = conn.get_remote_addr().unwrap_or_else(|| conn.get_addr());
+            match self.locator.unregister_with_address(addr).await {
                 Ok(Some(removed)) => {
                     if !removed.is_empty() {
                         self.locator_events

--- a/src/proxy/locator_db.rs
+++ b/src/proxy/locator_db.rs
@@ -558,6 +558,8 @@ impl Locator for DbLocator {
         let mut models = Entity::find()
             .filter(Column::Aor.eq(&target_aor))
             .order_by_desc(Column::LastModified)
+            .order_by_desc(Column::UpdatedAt)
+            .order_by_desc(Column::Id)
             .all(&self.db)
             .await
             .map_err(|e| anyhow::anyhow!("Database error on lookup by aor: {}", e))?;
@@ -566,6 +568,8 @@ impl Locator for DbLocator {
             models = Entity::find()
                 .filter(Column::Aor.contains(uri.host().to_string().as_str()))
                 .order_by_desc(Column::LastModified)
+                .order_by_desc(Column::UpdatedAt)
+                .order_by_desc(Column::Id)
                 .all(&self.db)
                 .await
                 .map_err(|e| anyhow::anyhow!("Database error on lookup by invalid host: {}", e))?;
@@ -586,6 +590,8 @@ impl Locator for DbLocator {
                     .filter(Column::Username.eq(&username_key))
                     .filter(Column::Realm.eq(&realm_key))
                     .order_by_desc(Column::LastModified)
+                    .order_by_desc(Column::UpdatedAt)
+                    .order_by_desc(Column::Id)
                     .all(&self.db)
                     .await
                     .map_err(|e| anyhow::anyhow!("Database error on lookup: {}", e))?;
@@ -596,6 +602,8 @@ impl Locator for DbLocator {
                     models = Entity::find()
                         .filter(Column::Username.eq(&username_key))
                         .order_by_desc(Column::LastModified)
+                        .order_by_desc(Column::UpdatedAt)
+                        .order_by_desc(Column::Id)
                         .all(&self.db)
                         .await
                         .map_err(|e| anyhow::anyhow!("Database error on username lookup: {}", e))?;

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -34,7 +34,7 @@ use crate::media::bridge::{BridgeEndpoint, BridgePeerBuilder};
 use crate::media::mixer::MediaMixer;
 use crate::media::negotiate::{CodecInfo, MediaNegotiator};
 use crate::media::recorder::Recorder;
-use crate::media::{FileTrack, RtpTrackBuilder, Track};
+use crate::media::{FileTrack, PlaybackEndReason, RtpTrackBuilder, Track};
 use crate::proxy::proxy_call::{
     dtmf::RtpDtmfDetector,
     media_peer::{MediaPeer, VoiceEnginePeer},
@@ -671,7 +671,11 @@ impl SipSession {
         route_via_home_proxy: bool,
     ) -> rsipstack::sip::Uri {
         if route_via_home_proxy && let Some(registered_aor) = target.registered_aor.as_ref() {
-            return registered_aor.clone();
+            let mut uri = registered_aor.clone();
+            if let Some(home_proxy) = target.home_proxy.as_ref() {
+                uri.host_with_port = home_proxy.addr.clone();
+            }
+            return uri;
         }
 
         target.aor.clone()
@@ -1207,6 +1211,9 @@ impl SipSession {
                 self.unschedule_timer(&terminated_dialog_id);
                 self.timers.remove(&terminated_dialog_id);
                 self.update_refresh_disabled.remove(&terminated_dialog_id);
+                // The remote BYE already terminated this leg; remove it before dropping
+                // its guard so guard cleanup does not send a second BYE back.
+                self.server.dialog_layer.remove_dialog(&terminated_dialog_id);
                 self.callee_guards
                     .retain(|guard| guard.id() != &terminated_dialog_id);
 
@@ -1419,78 +1426,6 @@ impl SipSession {
                 StatusCode::TemporarilyUnavailable,
                 Some("No targets to dial".to_string()),
             ))
-        }
-    }
-
-    async fn prepare_queue_early_answer(
-        &mut self,
-        agents: &[crate::call::Location],
-    ) -> Option<String> {
-        let caller_is_webrtc = self.is_caller_webrtc();
-        self.leg_transport.insert(
-            LegId::from("caller"),
-            if caller_is_webrtc {
-                rustrtc::TransportMode::WebRtc
-            } else {
-                rustrtc::TransportMode::Rtp
-            },
-        );
-
-        let Some(first_agent) = agents.first() else {
-            return self.ensure_caller_answer_sdp().await;
-        };
-
-        let callee_is_webrtc = first_agent.supports_webrtc;
-        self.leg_transport.insert(
-            LegId::from("callee"),
-            if callee_is_webrtc {
-                rustrtc::TransportMode::WebRtc
-            } else {
-                rustrtc::TransportMode::Rtp
-            },
-        );
-
-        if caller_is_webrtc == callee_is_webrtc {
-            self.caller_answer_uses_media_bridge = false;
-            self.callee_offer_uses_media_bridge = false;
-            return self.ensure_caller_answer_sdp().await;
-        }
-
-        if self.media_bridge.is_none() {
-            match self.create_callee_track(callee_is_webrtc).await {
-                Ok(callee_offer) => {
-                    self.callee_offer = Some(callee_offer);
-                }
-                Err(error) => {
-                    warn!(
-                        session_id = %self.context.session_id,
-                        error = %error,
-                        "Queue early answer: failed to prepare bridge, falling back to caller media"
-                    );
-                    self.caller_answer_uses_media_bridge = false;
-                    self.callee_offer_uses_media_bridge = false;
-                    return self.ensure_caller_answer_sdp().await;
-                }
-            }
-        }
-
-        match self.prepare_bridge_caller_answer().await {
-            Ok(answer) => {
-                self.answer = Some(answer.clone());
-                self.caller_answer_uses_media_bridge = true;
-                self.replace_caller_bridge_output_with_silence().await;
-                Some(answer)
-            }
-            Err(error) => {
-                warn!(
-                    session_id = %self.context.session_id,
-                    error = %error,
-                    "Queue early answer: failed to answer from bridge, falling back to caller media"
-                );
-                self.caller_answer_uses_media_bridge = false;
-                self.callee_offer_uses_media_bridge = false;
-                self.ensure_caller_answer_sdp().await
-            }
         }
     }
 
@@ -2294,10 +2229,13 @@ impl SipSession {
             return self.answer.clone();
         }
 
+        let can_update_confirmed_anchored_media = self.media_bridge.is_none()
+            || (self.caller_answer_uses_media_bridge && !self.callee_offer_uses_media_bridge);
+
         if self.server_dialog.state().is_confirmed()
             && self.answer.is_some()
             && self.media_profile.path == MediaPathMode::Anchored
-            && self.media_bridge.is_none()
+            && can_update_confirmed_anchored_media
         {
             debug!(
                 session_id = %self.context.session_id,
@@ -2796,7 +2734,21 @@ impl SipSession {
 
         let session_id = &self.context.session_id;
 
-        let caller_pc = Self::get_peer_pc(&self.caller_peer, Self::CALLER_TRACK_ID).await;
+        let caller_pc = if self.caller_answer_uses_media_bridge {
+            let Some(bridge) = self.media_bridge.as_ref() else {
+                warn!(
+                    session_id = %session_id,
+                    "Cannot start anchored forwarding: caller answer uses media bridge but bridge is missing"
+                );
+                return;
+            };
+            match self.leg_bridge_endpoint(&LegId::from("caller")) {
+                BridgeEndpoint::WebRtc => Some(bridge.webrtc_pc().clone()),
+                BridgeEndpoint::Rtp => Some(bridge.rtp_pc().clone()),
+            }
+        } else {
+            Self::get_peer_pc(&self.caller_peer, Self::CALLER_TRACK_ID).await
+        };
         let callee_pc = Self::get_peer_pc(&self.callee_peer, Self::CALLEE_TRACK_ID).await;
 
         let (Some(caller_pc), Some(callee_pc)) = (caller_pc, callee_pc) else {
@@ -5910,32 +5862,49 @@ impl SipSession {
                 let codec = CodecType::PCMU;
                 MediaNegotiator::codec_info_for_type(codec)
             });
+        let completion_notify = if await_completion {
+            Some(Arc::new(tokio::sync::Notify::new()))
+        } else {
+            None
+        };
 
         /// Route playback to a specific leg.
         macro_rules! play_to_leg {
-            ($leg_str:expr, $peer:expr, $bridge_endpoint:expr, $uses_bridge:expr) => {{
+            ($leg_str:expr, $bridge_endpoint:expr, $uses_bridge:expr) => {{
                 let target_tid = if $leg_str == "caller" && leg_id.is_none() {
                     base_track_id.clone()
                 } else {
                     format!("{}-{}", base_track_id, $leg_str)
                 };
-                let leg_track = FileTrack::new(target_tid.clone())
+                let mut leg_track = FileTrack::new(target_tid.clone())
                     .with_path(file_path.clone())
+                    .with_loop(loop_playback)
                     .with_codec_info(codec_info.clone());
-                if $uses_bridge {
-                    if let Some(ref bridge) = self.media_bridge {
-                        bridge
-                            .replace_output_with_file($bridge_endpoint, &leg_track)
-                            .await?;
-                        if $leg_str == "caller" {
-                            self.bridge_playback_track_id = Some(target_tid.clone());
-                        }
+                let app_runtime = self.app_runtime.clone();
+                let track_id = target_tid.clone();
+                let notify = completion_notify.clone();
+                leg_track = leg_track.with_on_end(Arc::new(move |reason| {
+                    let _ = app_runtime.inject_event(serde_json::json!({
+                        "type": "audio_complete",
+                        "track_id": track_id,
+                        "interrupted": matches!(reason, PlaybackEndReason::Interrupted)
+                    }));
+                    if let Some(notify) = notify.as_ref() {
+                        notify.notify_one();
                     }
-                } else {
-                    if let Err(e) = leg_track.start_playback_on(None).await {
-                        warn!(error = %e, "Failed to start playback on {}", $leg_str);
-                    }
-                    $peer.update_track(Box::new(leg_track.clone()), None).await;
+                }));
+                if !$uses_bridge {
+                    return Err(anyhow!("Playback requires media bridge for {} leg", $leg_str));
+                }
+                let bridge = self
+                    .media_bridge
+                    .clone()
+                    .ok_or_else(|| anyhow!("Playback requires active media bridge"))?;
+                bridge
+                    .replace_output_with_file($bridge_endpoint, &leg_track)
+                    .await?;
+                if $leg_str == "caller" {
+                    self.bridge_playback_track_id = Some(target_tid.clone());
                 }
                 self.playback_tracks
                     .insert(target_tid.clone(), leg_track);
@@ -5947,7 +5916,6 @@ impl SipSession {
             Some(ref lid) if lid == &LegId::from("caller") => {
                 play_to_leg!(
                     "caller",
-                    self.caller_peer,
                     self.leg_bridge_endpoint(&LegId::from("caller")),
                     self.caller_answer_uses_media_bridge
                 );
@@ -5956,32 +5924,21 @@ impl SipSession {
             Some(ref lid) if lid == &LegId::from("callee") => {
                 play_to_leg!(
                     "callee",
-                    self.callee_peer,
                     self.leg_bridge_endpoint(&LegId::from("callee")),
                     self.callee_offer_uses_media_bridge
                 );
             }
             // Dynamic leg from peers
             Some(ref lid) => {
-                let peer = self
-                    .peers
-                    .get(lid)
-                    .ok_or_else(|| anyhow!("Leg not found: {}", lid))?;
-                let target_tid = format!("{}-{}", base_track_id, lid);
-                let leg_track = FileTrack::new(target_tid.clone())
-                    .with_path(file_path.clone())
-                    .with_codec_info(codec_info.clone());
-                if let Err(e) = leg_track.start_playback_on(None).await {
-                    warn!(error = %e, "Failed to start playback on leg {}", lid);
-                }
-                peer.update_track(Box::new(leg_track.clone()), None).await;
-                self.playback_tracks.insert(target_tid.clone(), leg_track);
+                return Err(anyhow!(
+                    "Playback to dynamic leg {} requires media bridge output mapping",
+                    lid
+                ));
             }
             // None = caller only (backward compatible)
             None => {
                 play_to_leg!(
                     "caller",
-                    self.caller_peer,
                     self.leg_bridge_endpoint(&LegId::from("caller")),
                     self.caller_answer_uses_media_bridge
                 );
@@ -5990,29 +5947,15 @@ impl SipSession {
 
         info!(track_id = %base_track_id, file = %file_path, "Playback started");
 
-        // Spawn completion watcher for the first (or only) track
-        if await_completion && !loop_playback {
-            let first_leg = match leg_id {
-                Some(ref l) => l.to_string(),
-                None => "caller".to_string(),
-            };
-            let first_tid = if leg_id.is_none() {
-                base_track_id.clone()
-            } else {
-                format!("{}-{}", base_track_id, first_leg)
-            };
-            if let Some(track) = self.playback_tracks.get(&first_tid) {
-                let app_runtime = self.app_runtime.clone();
-                let track_id_clone = first_tid.clone();
-                let track_clone = track.clone();
-                tokio::spawn(async move {
-                    track_clone.wait_for_completion().await;
-                    let _ = app_runtime.inject_event(serde_json::json!({
-                        "type": "audio_complete",
-                        "track_id": track_id_clone,
-                        "interrupted": false
-                    }));
-                });
+        if let Some(notify) = completion_notify {
+            let cancel = self.cancel_token.clone();
+            tokio::select! {
+                _ = notify.notified() => {
+                    debug!(track_id = %base_track_id, "Playback completed before returning");
+                }
+                _ = cancel.cancelled() => {
+                    debug!(track_id = %base_track_id, "Playback wait cancelled");
+                }
             }
         }
 
@@ -7041,15 +6984,21 @@ mod tests {
         let contact_uri =
             rsipstack::sip::Uri::try_from("sip:lp@172.25.52.29:63647;transport=UDP").unwrap();
         let registered_aor = rsipstack::sip::Uri::try_from("sip:lp@rustpbx.com").unwrap();
+        let home_proxy = SipAddr {
+            r#type: Some(rsipstack::sip::Transport::Udp),
+            addr: rsipstack::sip::HostWithPort::try_from("10.0.0.2:5070").unwrap(),
+        };
+        let expected = rsipstack::sip::Uri::try_from("sip:lp@10.0.0.2:5070").unwrap();
 
         let target = Location {
             aor: contact_uri,
             registered_aor: Some(registered_aor.clone()),
+            home_proxy: Some(home_proxy),
             ..Default::default()
         };
 
         let resolved = SipSession::resolve_outbound_callee_uri(&target, true);
-        assert_eq!(resolved, registered_aor);
+        assert_eq!(resolved, expected);
     }
 
     #[test]

--- a/src/proxy/proxy_call/sip_session/queue.rs
+++ b/src/proxy/proxy_call/sip_session/queue.rs
@@ -45,7 +45,6 @@ impl SipSession {
         if resolved_agents.is_empty() {
             warn!("No agents available after resolving queue targets");
 
-            self.prepare_queue_fallback_audio_media().await;
             self.play_queue_transfer_prompt_before_bridge(transfer_prompt)
                 .await;
 
@@ -54,7 +53,7 @@ impl SipSession {
 
         if plan.accept_immediately {
             info!("Queue: answering call immediately");
-            let caller_answer = self.prepare_queue_early_answer(&resolved_agents).await;
+            let caller_answer = self.prepare_app_caller_media_bridge().await;
             if let Err(e) = self.accept_call(None, caller_answer, None).await {
                 warn!(error = %e, "Failed to answer call in queue");
             }
@@ -67,6 +66,7 @@ impl SipSession {
             if let Some(ref audio_file) = hold.audio_file {
                 info!(file = %audio_file, "Queue: starting hold music");
 
+                self.prepare_queue_playback_media().await;
                 match self
                     .play_audio_file(
                         audio_file,
@@ -76,7 +76,7 @@ impl SipSession {
                     )
                     .await
                 {
-                    Ok(()) => {
+                    Ok(_) => {
                         info!(track_id = %Self::QUEUE_HOLD_TRACK_ID, "Queue: hold music started");
                         true
                     }
@@ -199,21 +199,12 @@ impl SipSession {
         };
 
         info!(file = %audio_file, "Queue: playing transfer prompt before bridging agent audio");
+        self.prepare_queue_playback_media().await;
         match self
             .play_audio_file(audio_file, true, "queue-transfer-prompt", false)
             .await
         {
-            Ok(()) => {
-                let maybe_track = self.playback_tracks.get("queue-transfer-prompt").cloned();
-                let cancel = self.cancel_token.clone();
-                if let Some(track) = maybe_track {
-                    tokio::select! {
-                        _ = track.wait_for_completion() => {}
-                        _ = cancel.cancelled() => {}
-                    }
-                }
-                self.stop_playback_track("queue-transfer-prompt", false)
-                    .await;
+            Ok(_) => {
                 info!(file = %audio_file, "Queue: transfer prompt completed");
             }
             Err(error) => {
@@ -241,21 +232,19 @@ impl SipSession {
                 _ => None,
             });
 
+        let wait_for_failure_audio = matches!(
+            plan.fallback,
+            Some(QueueFallbackAction::Failure(_))
+        );
         if let Some(ref audio_file) = pre_action_audio {
-            self.prepare_queue_fallback_audio_media().await;
-            if let Err(e) = self
-                .play_audio_file(audio_file, true, "caller", false)
+            self.prepare_queue_playback_media().await;
+            match self
+                .play_audio_file(audio_file, wait_for_failure_audio, "caller", false)
                 .await
             {
-                warn!(error = %e, "Failed to play queue failure audio");
-            } else {
-                let maybe_track = self.playback_tracks.get("caller").cloned();
-                let cancel = self.cancel_token.clone();
-                if let Some(track) = maybe_track {
-                    tokio::select! {
-                        _ = track.wait_for_completion() => {}
-                        _ = cancel.cancelled() => {}
-                    }
+                Ok(()) => {}
+                Err(e) => {
+                    warn!(error = %e, "Failed to play queue failure audio");
                 }
             }
         }
@@ -391,17 +380,19 @@ impl SipSession {
         }
     }
 
-    pub(super) async fn prepare_queue_fallback_audio_media(&mut self) {
+    pub(super) async fn prepare_queue_playback_media(&mut self) {
         if self.server_dialog.state().is_confirmed() {
-            let _ = self.ensure_caller_answer_sdp().await;
+            if !self.caller_answer_uses_media_bridge {
+                warn!("Queue playback: caller leg is already answered without media bridge");
+            }
             return;
         }
 
-        let caller_answer = self.ensure_caller_answer_sdp().await;
+        let caller_answer = self.prepare_app_caller_media_bridge().await;
         if let Err(error) = self.accept_call(None, caller_answer, None).await {
             warn!(
                 error = %error,
-                "Queue fallback: failed to prepare caller media before fallback audio"
+                "Queue playback: failed to prepare caller media before audio"
             );
         }
     }

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -620,10 +620,19 @@ impl SipServerBuilder {
         // Create cluster event hub for inter-node sync
         let cluster_peer_ips: Vec<IpAddr> = self.cluster_peers.iter().map(|p| p.ip()).collect();
         let cluster_event_hub: Option<Arc<ClusterEventHub>> = if !self.cluster_peers.is_empty() {
+            let local_cluster_ip = rtp_config
+                .external_ip
+                .as_deref()
+                .unwrap_or(&config.addr)
+                .parse::<IpAddr>()
+                .map_err(|e| anyhow!("failed to parse cluster local ip address: {}", e))?;
+            let local_cluster_port = config.udp_port.unwrap_or(5060);
+            let local_cluster_addr = SocketAddr::new(local_cluster_ip, local_cluster_port);
             Some(Arc::new(ClusterEventHub::new(
                 locator_events.clone(),
                 presence_manager.clone(),
                 endpoint.inner.clone(),
+                local_cluster_addr,
                 self.cluster_peers.clone(),
             )))
         } else {


### PR DESCRIPTION
## Summary
- replace playback completion waiting with `FileTrack` end callbacks and update IVR/file-track tests to match
- keep cluster MESSAGE transactions alive long enough to receive immediate final responses
- preserve remote/local address handling for cluster/auth/locator routing paths

## Validation
- `cargo check --features contact-center --bin rustpbx`
- `cargo test --features contact-center audio_complete -- --nocapture`
- `cargo test --features contact-center file_track -- --nocapture`
- `cargo test --features contact-center ivr_e2e -- --nocapture`
- `cargo test --features contact-center test_tick_assign_emits_call_dequeued_event -- --nocapture`

## Notes
- broad `queue` test filtering still exposes separate SIP/RTP E2E failures around test UA registration against a call-only test PBX; that is outside these three commits.