### PR TITLE
Fix queue transfer signaling and cleanup handling

### DIFF
--- a/src/callrecord/recording_upload.rs
+++ b/src/callrecord/recording_upload.rs
@@ -145,6 +145,10 @@ impl RecordingUploadHook {
 #[async_trait]
 impl CallRecordHook for RecordingUploadHook {
     async fn on_record_completed(&self, record: &mut CallRecord) -> anyhow::Result<()> {
+        if record.answer_time.is_none() {
+            return Ok(());
+        }
+
         if !self.policy.uploads_recording() {
             return Ok(());
         }

--- a/src/callrecord/sipflow_upload.rs
+++ b/src/callrecord/sipflow_upload.rs
@@ -22,6 +22,10 @@ pub struct SipFlowUploadHook {
 #[async_trait]
 impl CallRecordHook for SipFlowUploadHook {
     async fn on_record_completed(&self, record: &mut CallRecord) -> anyhow::Result<()> {
+        if record.answer_time.is_none() {
+            return Ok(());
+        }
+
         let backend = self.backend.clone();
         let upload_config = self.upload_config.clone();
         let db = self.db.clone();
@@ -251,6 +255,7 @@ mod tests {
         let mut record = CallRecord::default();
         record.call_id = "test-call-id".to_string();
         record.start_time = now - chrono::Duration::seconds(30);
+        record.answer_time = Some(now - chrono::Duration::seconds(20));
         record.end_time = now;
         record.caller = "alice".to_string();
         record.callee = "bob".to_string();

--- a/src/proxy/proxy_call/reporter.rs
+++ b/src/proxy/proxy_call/reporter.rs
@@ -35,6 +35,7 @@ impl CallReporter {
             start_time
                 + Duration::from_std(at.duration_since(self.context.start_time)).unwrap_or_default()
         });
+        let call_was_accepted = snapshot.answer_time.is_some();
 
         let status_code = snapshot
             .last_error
@@ -45,7 +46,7 @@ impl CallReporter {
         let hangup_reason = snapshot.hangup_reason.clone().or_else(|| {
             if snapshot.last_error.is_some() {
                 Some(CallRecordHangupReason::Failed)
-            } else if snapshot.answer_time.is_some() {
+            } else if call_was_accepted {
                 Some(CallRecordHangupReason::BySystem)
             } else {
                 Some(CallRecordHangupReason::Failed)
@@ -122,7 +123,7 @@ impl CallReporter {
         let direction = self.context.dialplan.direction.to_string();
 
         // Helper to resolve call status (copied from proxy_call.rs logic)
-        let status = if snapshot.answer_time.is_some() {
+        let status = if call_was_accepted {
             "completed".to_string()
         } else if snapshot.last_error.is_some() {
             "failed".to_string()
@@ -147,7 +148,8 @@ impl CallReporter {
 
         let mut recorder = Vec::new();
 
-        if self.context.dialplan.recording.enabled
+        if call_was_accepted
+            && self.context.dialplan.recording.enabled
             && let Some(recorder_config) = self.context.dialplan.recording.option.as_ref()
             && !recorder_config.recorder_file.is_empty()
         {
@@ -164,6 +166,7 @@ impl CallReporter {
         tracing::info!(
             recording = ?self.context.dialplan.recording,
             has_sipflow_backend = ?has_sipflow_backend,
+            call_was_accepted,
             "Call recording files collected: {:?}",
             recorder
         );
@@ -194,7 +197,8 @@ impl CallReporter {
             ..Default::default()
         };
 
-        if details.recording_url.is_none()
+        if call_was_accepted
+            && details.recording_url.is_none()
             && self.server.proxy_config.recording.is_none()
             && let Some(crate::config::SipFlowConfig::Local {
                 upload:

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -2380,14 +2380,34 @@ impl SipSession {
             Some("All targets failed".to_string()),
         );
         let total = targets.len() as u32;
+        let mut caller_end_check = tokio::time::interval(Duration::from_millis(100));
 
-        while let Some(join_result) = fork_set.next().await {
-            if self.cancel_token.is_cancelled() {
-                return Err((
-                    StatusCode::RequestTerminated,
-                    Some("Caller cancelled".to_string()),
-                ));
-            }
+        while !fork_set.is_empty() {
+            let join_result = tokio::select! {
+                _ = caller_end_check.tick() => {
+                    if self.server_dialog.state().is_terminated() {
+                        info!(
+                            session_id = %self.context.session_id,
+                            "Caller dialog terminated while parallel callee INVITEs were pending"
+                        );
+                        fork_cancel.cancel();
+                        self.cancel_token.cancel();
+                        return Err((
+                            StatusCode::RequestTerminated,
+                            Some("Caller cancelled".to_string()),
+                        ));
+                    }
+                    continue;
+                }
+                _ = self.cancel_token.cancelled() => {
+                    fork_cancel.cancel();
+                    return Err((
+                        StatusCode::RequestTerminated,
+                        Some("Caller cancelled".to_string()),
+                    ));
+                }
+                Some(join_result) = fork_set.next() => join_result,
+            };
 
             match join_result {
                 Ok(Some((winner_idx, Ok((dialog, response)), callee_uri))) => {

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -1489,7 +1489,9 @@ impl SipSession {
 
 
                 Some(cmd) = cmd_rx.recv() => {
-                    let result = self.execute_command(cmd).await;
+                    let result = self
+                        .execute_command(cmd, Some(&mut callee_state_rx))
+                        .await;
                     if !result.success {
                         warn!(error = ?result.message, "Command execution failed");
                     }
@@ -1908,6 +1910,11 @@ impl SipSession {
                     .await?;
             }
             DialogState::Terminated(terminated_dialog_id, reason) => {
+                let connected_callee_terminated =
+                    self.meta.connected_callee_dialog_id.as_ref() == Some(&terminated_dialog_id);
+                let tracked_callee_terminated =
+                    self.callee_dialogs.contains_key(&terminated_dialog_id);
+
                 self.pending_hangup.remove(&terminated_dialog_id);
                 self.callee_dialogs.remove(&terminated_dialog_id);
                 self.legs.retain_dialogs_by_dialog_id(&terminated_dialog_id);
@@ -1922,8 +1929,15 @@ impl SipSession {
                 self.callee_guards
                     .retain(|guard| guard.id() != &terminated_dialog_id);
 
-                let connected_callee_terminated =
-                    self.meta.connected_callee_dialog_id.as_ref() == Some(&terminated_dialog_id);
+                if !tracked_callee_terminated && !connected_callee_terminated {
+                    debug!(
+                        dialog_id = %terminated_dialog_id,
+                        ?reason,
+                        "Ignoring terminated untracked callee dialog"
+                    );
+                    return Ok(());
+                }
+
                 if self.meta.connected_callee_dialog_id.is_some() && !connected_callee_terminated {
                     debug!(
                         dialog_id = %terminated_dialog_id,
@@ -2243,6 +2257,12 @@ impl SipSession {
         let dialog_layer = self.server.dialog_layer.clone();
         let fork_cancel = CancellationToken::new();
         let mut fork_set = FuturesUnordered::new();
+        let state_tx = self.callee_event_tx.clone().ok_or_else(|| {
+            (
+                StatusCode::ServerInternalError,
+                Some("No callee event sender".to_string()),
+            )
+        })?;
 
         for (idx, target) in targets.iter().enumerate() {
             if fork_cancel.is_cancelled() {
@@ -2330,8 +2350,7 @@ impl SipSession {
                 ..Default::default()
             };
 
-            // Each fork gets its own state channel so events don't interleave
-            let (fork_tx, _fork_rx) = mpsc::unbounded_channel();
+            let fork_tx = state_tx.clone();
             let dlg = dialog_layer.clone();
             let ct = fork_cancel.clone();
 
@@ -6196,7 +6215,11 @@ impl SipSession {
 }
 
 impl SipSession {
-    pub async fn execute_command(&mut self, command: CallCommand) -> CommandResult {
+    pub async fn execute_command(
+        &mut self,
+        command: CallCommand,
+        callee_state_rx: Option<&mut mpsc::UnboundedReceiver<DialogState>>,
+    ) -> CommandResult {
         let capability_check = self.check_capability(&command);
 
         let degradation_reason = match capability_check {
@@ -6210,7 +6233,7 @@ impl SipSession {
             MediaCapabilityCheck::Allowed => None,
         };
 
-        let mut result = self.process_command(command).await;
+        let mut result = self.process_command(command, callee_state_rx).await;
 
         if let Some(reason) = degradation_reason {
             result.media_degraded = true;
@@ -6225,7 +6248,11 @@ impl SipSession {
         ctx.check_media_capability(command)
     }
 
-    async fn process_command(&mut self, command: CallCommand) -> CommandResult {
+    async fn process_command(
+        &mut self,
+        command: CallCommand,
+        mut callee_state_rx: Option<&mut mpsc::UnboundedReceiver<DialogState>>,
+    ) -> CommandResult {
         match command {
             CallCommand::Answer { leg_id } => {
                 if leg_id.0 == "caller" {
@@ -6362,10 +6389,20 @@ impl SipSession {
                 leg_id,
                 target,
                 attended,
-            } => match self.handle_transfer(leg_id, target, attended).await {
-                Ok(_) => CommandResult::success(),
-                Err(e) => CommandResult::failure(e.to_string()),
-            },
+            } => {
+                let Some(callee_state_rx) = callee_state_rx.as_deref_mut() else {
+                    return CommandResult::failure(
+                        "No callee state receiver available for transfer".to_string(),
+                    );
+                };
+                match self
+                    .handle_transfer(leg_id, target, attended, callee_state_rx)
+                    .await
+                {
+                    Ok(_) => CommandResult::success(),
+                    Err(e) => CommandResult::failure(e.to_string()),
+                }
+            }
 
             CallCommand::TransferComplete { consult_leg } => {
                 match self.handle_transfer_complete(consult_leg).await {
@@ -9049,9 +9086,15 @@ mod tests {
             caller_peer,
             callee_peer,
         );
+        let (callee_tx, mut callee_rx) = mpsc::unbounded_channel();
+        session.callee_event_tx = Some(callee_tx);
 
         let result = session
-            .handle_blind_transfer(LegId::from("caller"), "queue:test-queue".to_string())
+            .handle_blind_transfer(
+                LegId::from("caller"),
+                "queue:test-queue".to_string(),
+                &mut callee_rx,
+            )
             .await;
 
         assert!(
@@ -9112,9 +9155,15 @@ mod tests {
             caller_peer,
             callee_peer,
         );
+        let (callee_tx, mut callee_rx) = mpsc::unbounded_channel();
+        session.callee_event_tx = Some(callee_tx);
 
         let result = session
-            .handle_blind_transfer(LegId::from("caller"), "queue:nonexistent".to_string())
+            .handle_blind_transfer(
+                LegId::from("caller"),
+                "queue:nonexistent".to_string(),
+                &mut callee_rx,
+            )
             .await;
 
         assert!(

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -5119,16 +5119,25 @@ impl SipSession {
 
     async fn get_local_reinvite_pc(&self, side: DialogSide) -> Option<rustrtc::PeerConnection> {
         if let Some(bridge) = &self.media.media_bridge {
-            let leg_is_webrtc = match side {
-                DialogSide::Caller => self.is_caller_webrtc(),
-                DialogSide::Callee => self.is_callee_webrtc(),
+            let bridge_endpoint = match side {
+                DialogSide::Caller if self.media.caller_answer_uses_media_bridge => {
+                    Some(self.leg_bridge_endpoint(&LegId::from("caller")))
+                }
+                DialogSide::Callee if self.media.callee_offer_uses_media_bridge => {
+                    Some(self.leg_bridge_endpoint(&LegId::from("callee")))
+                }
+                _ => None,
             };
 
-            return Some(if leg_is_webrtc {
-                bridge.caller_pc().clone()
-            } else {
-                bridge.callee_pc().clone()
-            });
+            // A session may keep an app/IVR bridge after transferring to a
+            // normal SIP callee. Only use the bridge PC for a leg explicitly
+            // negotiated on that bridge; otherwise use the leg's own track PC.
+            if let Some(endpoint) = bridge_endpoint {
+                return Some(match endpoint {
+                    BridgeEndpoint::Caller => bridge.caller_pc().clone(),
+                    BridgeEndpoint::Callee => bridge.callee_pc().clone(),
+                });
+            }
         }
 
         let (peer, track_id) = match side {
@@ -8505,7 +8514,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_local_reinvite_pc_uses_bridge_when_present() {
+    async fn test_get_local_reinvite_pc_uses_bridge_only_for_bridge_backed_leg() {
         use crate::call::{DialDirection, Dialplan, TransactionCookie};
         use crate::proxy::proxy_call::test_util::tests::MockMediaPeer;
         use crate::proxy::tests::common::{
@@ -8558,6 +8567,8 @@ mod tests {
 
         session.media.media_bridge =
             Some(BridgePeerBuilder::new("test-bridge".to_string()).build());
+        session.media.caller_answer_uses_media_bridge = true;
+        session.media.callee_offer_uses_media_bridge = false;
         session
             .legs
             .transports
@@ -8572,6 +8583,15 @@ mod tests {
         assert!(pc.is_some(), "bridge-backed caller leg should resolve a PC");
         assert_eq!(caller_peer.get_tracks_call_count(), 0);
         assert_eq!(callee_peer.get_tracks_call_count(), 0);
+
+        let pc = session.get_local_reinvite_pc(DialogSide::Callee).await;
+
+        assert!(
+            pc.is_none(),
+            "non-bridge callee leg should resolve through its own track PC"
+        );
+        assert_eq!(caller_peer.get_tracks_call_count(), 0);
+        assert_eq!(callee_peer.get_tracks_call_count(), 1);
     }
 
     #[tokio::test]

--- a/src/proxy/proxy_call/sip_session/queue.rs
+++ b/src/proxy/proxy_call/sip_session/queue.rs
@@ -70,7 +70,7 @@ impl SipSession {
             self.play_queue_transfer_prompt_before_bridge(transfer_prompt)
                 .await;
 
-            return self.execute_queue_fallback(plan).await;
+            return self.execute_queue_fallback(plan, callee_state_rx).await;
         }
 
         if plan.accept_immediately {
@@ -148,7 +148,7 @@ impl SipSession {
             }
             Err(e) => {
                 warn!(error = ?e, "Queue: all agents failed, executing fallback");
-                self.execute_queue_fallback(plan).await
+                self.execute_queue_fallback(plan, callee_state_rx).await
             }
         }
     }
@@ -248,6 +248,7 @@ impl SipSession {
     pub(super) async fn execute_queue_fallback(
         &mut self,
         plan: &crate::call::QueuePlan,
+        callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
     ) -> Result<(), (StatusCode, Option<String>)> {
         use crate::call::{FailureAction, QueueFallbackAction, TransferEndpoint};
 
@@ -295,19 +296,24 @@ impl SipSession {
 
                 match target {
                     TransferEndpoint::Uri(uri) => {
-                        Box::pin(self.handle_blind_transfer(LegId::from("caller"), uri.clone()))
-                            .await
-                            .map_err(|e| {
-                                (
-                                    StatusCode::TemporarilyUnavailable,
-                                    Some(format!("Transfer failed: {}", e)),
-                                )
-                            })
+                        Box::pin(self.handle_blind_transfer(
+                            LegId::from("caller"),
+                            uri.clone(),
+                            callee_state_rx,
+                        ))
+                        .await
+                        .map_err(|e| {
+                            (
+                                StatusCode::TemporarilyUnavailable,
+                                Some(format!("Transfer failed: {}", e)),
+                            )
+                        })
                     }
                     TransferEndpoint::Queue(queue_name) => Box::pin(self.handle_queue_transfer(
                         LegId::from("caller"),
                         queue_name,
                         None,
+                        callee_state_rx,
                     ))
                     .await
                     .map_err(|e| {
@@ -331,14 +337,18 @@ impl SipSession {
             Some(QueueFallbackAction::Redirect { target }) => {
                 info!(target = %target, "Queue fallback - redirecting call");
 
-                Box::pin(self.handle_blind_transfer(LegId::from("caller"), target.to_string()))
-                    .await
-                    .map_err(|e| {
-                        (
-                            StatusCode::TemporarilyUnavailable,
-                            Some(format!("Redirect failed: {}", e)),
-                        )
-                    })
+                Box::pin(self.handle_blind_transfer(
+                    LegId::from("caller"),
+                    target.to_string(),
+                    callee_state_rx,
+                ))
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::TemporarilyUnavailable,
+                        Some(format!("Redirect failed: {}", e)),
+                    )
+                })
             }
             Some(QueueFallbackAction::Queue { name }) => {
                 if name.starts_with("skill-group:") {
@@ -351,14 +361,18 @@ impl SipSession {
                         if !agents.is_empty() {
                             info!(agents = ?agents, "Resolved skill group to agents");
                             let target = agents[0].clone();
-                            Box::pin(self.handle_blind_transfer(LegId::from("caller"), target))
-                                .await
-                                .map_err(|e| {
-                                    (
-                                        StatusCode::TemporarilyUnavailable,
-                                        Some(format!("Transfer failed: {}", e)),
-                                    )
-                                })
+                            Box::pin(self.handle_blind_transfer(
+                                LegId::from("caller"),
+                                target,
+                                callee_state_rx,
+                            ))
+                            .await
+                            .map_err(|e| {
+                                (
+                                    StatusCode::TemporarilyUnavailable,
+                                    Some(format!("Transfer failed: {}", e)),
+                                )
+                            })
                         } else {
                             warn!(skill_group = %skill_group_id, "No agents found for this skill group");
                             Err((
@@ -378,8 +392,13 @@ impl SipSession {
                     }
                 } else {
                     info!(queue = %name, "Queue fallback - transfer to another queue");
-                    match Box::pin(self.handle_queue_transfer(LegId::from("caller"), name, None))
-                        .await
+                    match Box::pin(self.handle_queue_transfer(
+                        LegId::from("caller"),
+                        name,
+                        None,
+                        callee_state_rx,
+                    ))
+                    .await
                     {
                         Ok(_) => {
                             info!(queue = %name, "Queue fallback - re-enqueue succeeded");

--- a/src/proxy/proxy_call/sip_session/transfer.rs
+++ b/src/proxy/proxy_call/sip_session/transfer.rs
@@ -93,6 +93,7 @@ impl SipSession {
         leg_id: LegId,
         target: String,
         attended: bool,
+        callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
     ) -> Result<()> {
         info!(%leg_id, %target, %attended, "Handling transfer");
 
@@ -111,7 +112,8 @@ impl SipSession {
 
         if attended {
             if !target.is_empty() {
-                self.handle_replace_transfer(leg_id, target).await?;
+                self.handle_replace_transfer(leg_id, target, callee_state_rx)
+                    .await?;
             } else {
                 self.update_leg_state(&leg_id, LegState::Hold);
                 info!(
@@ -119,7 +121,8 @@ impl SipSession {
                 );
             }
         } else {
-            self.handle_blind_transfer(leg_id, target).await?;
+            self.handle_blind_transfer(leg_id, target, callee_state_rx)
+                .await?;
         }
 
         Ok(())
@@ -129,11 +132,13 @@ impl SipSession {
         &mut self,
         leg_id: LegId,
         target: String,
+        callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
     ) -> Result<()> {
         match parse_transfer_target(&target) {
             TransferTarget::Queue { name, return_ivr } => {
                 info!(%leg_id, queue = %name, ?return_ivr, "Handling queue transfer");
-                self.handle_queue_transfer(leg_id, &name, return_ivr).await
+                self.handle_queue_transfer(leg_id, &name, return_ivr, callee_state_rx)
+                    .await
             }
             TransferTarget::Ivr { name } => {
                 info!(%leg_id, ivr = %name, "Handling IVR transfer by starting IvrApp");
@@ -157,14 +162,9 @@ impl SipSession {
                         aor: refer_to_uri,
                         ..Default::default()
                     };
-                    // Create a proper dialog-state channel so early media (183) from the
-                    // B-leg propagates correctly during the transfer INVITE.
-                    let (callee_tx, mut callee_rx) = mpsc::unbounded_channel::<DialogState>();
-                    let prev_callee_tx = self.callee_event_tx.replace(callee_tx);
                     let result = self
-                        .try_single_target(&location, &mut callee_rx, None)
+                        .try_single_target(&location, callee_state_rx, None)
                         .await;
-                    self.callee_event_tx = prev_callee_tx;
                     return result.map_err(|(code, reason)| {
                         anyhow!(
                             "B-leg transfer failed: {:?} - {}",
@@ -288,6 +288,7 @@ impl SipSession {
         leg_id: LegId,
         queue_name: &str,
         return_ivr: Option<String>,
+        callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
     ) -> Result<()> {
         info!(%leg_id, queue = %queue_name, ?return_ivr, "Starting queue transfer");
 
@@ -335,12 +336,7 @@ impl SipSession {
             queue_plan.failure_audio = return_ivr_fallback_audio;
         }
 
-        // Create a proper dialog-state channel so early media (183) from agents
-        // propagates correctly during queue-driven transfers at runtime.
-        let (callee_tx, mut callee_rx) = mpsc::unbounded_channel::<DialogState>();
-        let prev_callee_tx = self.callee_event_tx.replace(callee_tx);
-        let queue_result = self.execute_queue(&queue_plan, &mut callee_rx).await;
-        self.callee_event_tx = prev_callee_tx;
+        let queue_result = self.execute_queue(&queue_plan, callee_state_rx).await;
 
         match queue_result {
             Ok(()) => {
@@ -575,6 +571,7 @@ impl SipSession {
         &mut self,
         leg_id: LegId,
         target: String,
+        callee_state_rx: &mut mpsc::UnboundedReceiver<DialogState>,
     ) -> Result<()> {
         let replaces = self
             .build_replaces_header()
@@ -587,7 +584,8 @@ impl SipSession {
             format!("{}?Replaces={}", target, encoded_replaces)
         };
 
-        self.handle_blind_transfer(leg_id, refer_target).await
+        self.handle_blind_transfer(leg_id, refer_target, callee_state_rx)
+            .await
     }
 
     pub(super) async fn emit_refer_event(

--- a/src/proxy/tests/test_sip_session_regressions.rs
+++ b/src/proxy/tests/test_sip_session_regressions.rs
@@ -463,9 +463,11 @@ async fn test_queue_transfer_without_return_ivr_keeps_hangup_fallback_when_no_ag
     );
     let config = make_queue_hangup_config("support");
     let mut session = build_session_with_config(dialplan, config).await;
+    let (callee_tx, mut callee_rx) = mpsc::unbounded_channel();
+    session.callee_event_tx = Some(callee_tx);
 
     let err = session
-        .handle_queue_transfer(LegId::from("caller"), "support", None)
+        .handle_queue_transfer(LegId::from("caller"), "support", None, &mut callee_rx)
         .await
         .expect_err("without return_ivr, hangup fallback should surface failure");
     assert!(
@@ -484,12 +486,19 @@ async fn test_queue_transfer_return_ivr_overrides_hangup_fallback_when_no_agents
     );
     let config = make_queue_hangup_config("support");
     let mut session = build_session_with_config(dialplan, config).await;
+    let (callee_tx, mut callee_rx) = mpsc::unbounded_channel();
+    session.callee_event_tx = Some(callee_tx);
 
     let runtime = Arc::new(StartOnlyRuntime::new());
     session.app_runtime = runtime.clone();
 
     session
-        .handle_queue_transfer(LegId::from("caller"), "support", Some("hello".to_string()))
+        .handle_queue_transfer(
+            LegId::from("caller"),
+            "support",
+            Some("hello".to_string()),
+            &mut callee_rx,
+        )
         .await
         .expect("return_ivr should override hangup fallback and start IVR");
 


### PR DESCRIPTION
## Problem

Queue-driven transfers could split callee dialog state onto a temporary local channel instead of the session-owned dialog state receiver. That made answer/provisional/final dialog state handling inconsistent during IVR -> queue -> agent flows, especially when the caller cancelled or when callee-side signaling needed to reach the main session loop.

A related re-INVITE path could answer against the wrong PeerConnection, and parallel queue calls could leave pending callee INVITEs alive after the caller had already hung up. Failed or unanswered calls could also still try to upload recording artifacts.

## What changed

- Use the shared session dialog-state sender for queue callee legs instead of creating a temporary local channel.
- Route re-INVITE handling to the correct PeerConnection for the active leg.
- Check caller cancellation while parallel queue legs are still ringing so pending callee INVITEs are cancelled and cleaned up.
- Skip recording upload work for calls that were not accepted or did not produce usable recording artifacts.
- Extend the SIP session regression coverage around these paths.

## Validation

- `cargo check --features "contact-center,wholesale"`
- Manual Docker compose validation for call-node -> agent-node routing, including caller cancel propagation through pending queue/agent legs and reject/cancel signaling behavior.
