### PR TITLE
Normalize schema definitions for Postgres compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,11 +157,13 @@ sea-orm = { version = "1.1.20", features = [
     "runtime-tokio-rustls",
     "sqlx-sqlite",
     "sqlx-mysql",
+    "sqlx-postgres",
 ] }
 sea-orm-migration = { version = "1.1.20", features = [
     "runtime-tokio-rustls",
     "sqlx-sqlite",
     "sqlx-mysql",
+    "sqlx-postgres",
 ] }
 argon2 = { version = "0.5.3", features = ["password-hash"] }
 object_store = { version = "0.13.2", features = ["aws", "azure", "gcp"] }
@@ -229,5 +231,3 @@ required-features = ["opus"]
 [[bin]]
 name = "verify-i18n"
 path = "tools/verify_i18n.rs"
-
-

--- a/src/addons/queue/models.rs
+++ b/src/addons/queue/models.rs
@@ -1,6 +1,9 @@
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
-use sea_orm_migration::schema::{boolean, json_null, string, text_null, timestamp, timestamp_null};
+use sea_orm_migration::schema::{
+    boolean, json_null, string_len, text_null, timestamp_with_time_zone as timestamp,
+    timestamp_with_time_zone_null as timestamp_null,
+};
 use sea_orm_migration::sea_query::ColumnDef;
 use sea_query::Expr;
 use serde::{Deserialize, Serialize};
@@ -48,7 +51,7 @@ impl MigrationTrait for Migration {
                             .primary_key()
                             .auto_increment(),
                     )
-                    .col(string(Column::Name).char_len(160))
+                    .col(string_len(Column::Name, 160))
                     .col(text_null(Column::Description))
                     .col(json_null(Column::Metadata))
                     .col(ColumnDef::new(Column::Spec).json().not_null())

--- a/src/models/add_user_mfa_columns.rs
+++ b/src/models/add_user_mfa_columns.rs
@@ -33,8 +33,7 @@ impl MigrationTrait for Migration {
                         .table(super::user::Entity)
                         .add_column(
                             ColumnDef::new(super::user::Column::MfaSecret)
-                                .string()
-                                .char_len(64)
+                                .string_len(64)
                                 .null(),
                         )
                         .to_owned(),
@@ -49,8 +48,7 @@ impl MigrationTrait for Migration {
                         .table(super::user::Entity)
                         .add_column(
                             ColumnDef::new(super::user::Column::AuthSource)
-                                .string()
-                                .char_len(32)
+                                .string_len(32)
                                 .not_null()
                                 .default("local"),
                         )

--- a/src/models/call_record.rs
+++ b/src/models/call_record.rs
@@ -2,8 +2,8 @@ use sea_orm::Set;
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::schema::{
-    boolean, integer, integer_null, json_null, string, string_null, text_null, timestamp,
-    timestamp_null,
+    boolean, integer, integer_null, json_null, string_len, string_len_null, text_null,
+    timestamp_with_time_zone as timestamp, timestamp_with_time_zone_null as timestamp_null,
 };
 use sea_orm_migration::sea_query::{ColumnDef, ForeignKeyAction as MigrationForeignKeyAction};
 use sea_query::Expr;
@@ -334,36 +334,32 @@ impl MigrationTrait for Migration {
                             .primary_key()
                             .auto_increment(),
                     )
-                    .col(string(Column::CallId).char_len(120))
-                    .col(string_null(Column::DisplayId).char_len(120))
-                    .col(string(Column::Direction).char_len(16))
-                    .col(string(Column::Status).char_len(32))
+                    .col(string_len(Column::CallId, 120))
+                    .col(string_len_null(Column::DisplayId, 120))
+                    .col(string_len(Column::Direction, 16))
+                    .col(string_len(Column::Status, 32))
                     .col(timestamp(Column::StartedAt).default(Expr::current_timestamp()))
                     .col(timestamp_null(Column::EndedAt))
                     .col(integer(Column::DurationSecs).not_null().default(0))
-                    .col(string_null(Column::FromNumber).char_len(64))
-                    .col(string_null(Column::ToNumber).char_len(64))
-                    .col(string_null(Column::CallerName).char_len(160))
-                    .col(string_null(Column::AgentName).char_len(160))
-                    .col(string_null(Column::Queue).char_len(120))
+                    .col(string_len_null(Column::FromNumber, 64))
+                    .col(string_len_null(Column::ToNumber, 64))
+                    .col(string_len_null(Column::CallerName, 160))
+                    .col(string_len_null(Column::AgentName, 160))
+                    .col(string_len_null(Column::Queue, 120))
                     .col(ColumnDef::new(Column::DepartmentId).big_integer().null())
                     .col(ColumnDef::new(Column::ExtensionId).big_integer().null())
                     .col(ColumnDef::new(Column::SipTrunkId).big_integer().null())
                     .col(ColumnDef::new(Column::RouteId).big_integer().null())
-                    .col(string_null(Column::SipGateway).char_len(160))
-                    .col(string_null(Column::RewriteOriginalFrom).char_len(64))
-                    .col(string_null(Column::RewriteOriginalTo).char_len(64))
+                    .col(string_len_null(Column::SipGateway, 160))
+                    .col(string_len_null(Column::RewriteOriginalFrom, 64))
+                    .col(string_len_null(Column::RewriteOriginalTo, 64))
                     .col(text_null(Column::CallerUri))
                     .col(text_null(Column::CalleeUri))
-                    .col(string_null(Column::RecordingUrl).char_len(255))
+                    .col(string_len_null(Column::RecordingUrl, 255))
                     .col(integer_null(Column::RecordingDurationSecs))
                     .col(boolean(Column::HasTranscript).default(false))
-                    .col(
-                        string(Column::TranscriptStatus)
-                            .char_len(32)
-                            .default("pending"),
-                    )
-                    .col(string_null(Column::TranscriptLanguage).char_len(16))
+                    .col(string_len(Column::TranscriptStatus, 32).default("pending"))
+                    .col(string_len_null(Column::TranscriptLanguage, 16))
                     .col(json_null(Column::Tags))
                     .col(json_null(Column::LegTimeline))
                     .col(json_null(Column::Metadata))

--- a/src/models/call_record_optimization_indices.rs
+++ b/src/models/call_record_optimization_indices.rs
@@ -63,16 +63,20 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
-        manager
-            .drop_index(
-                Index::drop()
-                    .if_exists()
-                    .name("idx_rustpbx_call_records_tags")
-                    .table(table)
-                    .to_owned(),
-            )
-            .await
-            .ok();
+        if manager
+            .has_index("rustpbx_call_records", "idx_rustpbx_call_records_tags")
+            .await?
+        {
+            manager
+                .drop_index(
+                    Index::drop()
+                        .name("idx_rustpbx_call_records_tags")
+                        .table(table)
+                        .to_owned(),
+                )
+                .await
+                .ok();
+        }
 
         manager
             .drop_index(

--- a/src/models/department.rs
+++ b/src/models/department.rs
@@ -1,6 +1,8 @@
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
-use sea_orm_migration::schema::{json_null, string, string_null, text_null, timestamp};
+use sea_orm_migration::schema::{
+    json_null, string_len, string_len_null, text_null, timestamp_with_time_zone as timestamp,
+};
 use sea_orm_migration::sea_query::ColumnDef;
 use sea_query::Expr;
 use serde::{Deserialize, Serialize};
@@ -46,12 +48,12 @@ impl MigrationTrait for Migration {
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(string(Column::Name).char_len(120))
-                    .col(string_null(Column::DisplayLabel).char_len(160))
-                    .col(string_null(Column::Slug).char_len(120))
+                    .col(string_len(Column::Name, 120))
+                    .col(string_len_null(Column::DisplayLabel, 160))
+                    .col(string_len_null(Column::Slug, 120))
                     .col(text_null(Column::Description))
-                    .col(string_null(Column::Color).char_len(32))
-                    .col(string_null(Column::ManagerContact).char_len(160))
+                    .col(string_len_null(Column::Color, 32))
+                    .col(string_len_null(Column::ManagerContact, 160))
                     .col(timestamp(Column::CreatedAt).default(Expr::current_timestamp()))
                     .col(timestamp(Column::UpdatedAt).default(Expr::current_timestamp()))
                     .col(json_null(Column::Metadata))

--- a/src/models/extension.rs
+++ b/src/models/extension.rs
@@ -2,7 +2,8 @@ use sea_orm::entity::prelude::*;
 use sea_orm::{ActiveValue::Set, ConnectionTrait, DbErr, QueryFilter};
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::schema::{
-    boolean, integer_null, string, string_null, text_null, timestamp, timestamp_null,
+    boolean, integer_null, string_len, string_len_null, text_null,
+    timestamp_with_time_zone as timestamp, timestamp_with_time_zone_null as timestamp_null,
 };
 use sea_orm_migration::sea_query::ColumnDef;
 use sea_query::Expr;
@@ -196,16 +197,16 @@ impl MigrationTrait for Migration {
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(string(Column::Extension).char_len(32))
-                    .col(string_null(Column::DisplayName).char_len(160))
-                    .col(string_null(Column::Email).char_len(160))
-                    .col(string_null(Column::Status).char_len(32))
+                    .col(string_len(Column::Extension, 32))
+                    .col(string_len_null(Column::DisplayName, 160))
+                    .col(string_len_null(Column::Email, 160))
+                    .col(string_len_null(Column::Status, 32))
                     .col(boolean(Column::LoginDisabled).default(false))
                     .col(boolean(Column::VoicemailDisabled).default(false))
                     .col(boolean(Column::AllowGuestCalls).default(false))
-                    .col(string_null(Column::SipPassword).char_len(160))
-                    .col(string_null(Column::CallForwardingMode).char_len(32))
-                    .col(string_null(Column::CallForwardingDestination).char_len(160))
+                    .col(string_len_null(Column::SipPassword, 160))
+                    .col(string_len_null(Column::CallForwardingMode, 32))
+                    .col(string_len_null(Column::CallForwardingDestination, 160))
                     .col(integer_null(Column::CallForwardingTimeout))
                     .col(timestamp_null(Column::RegisteredAt))
                     .col(text_null(Column::Notes))

--- a/src/models/extension_department.rs
+++ b/src/models/extension_department.rs
@@ -1,6 +1,6 @@
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
-use sea_orm_migration::schema::timestamp;
+use sea_orm_migration::schema::timestamp_with_time_zone as timestamp;
 use sea_orm_migration::sea_query::{
     ColumnDef, ForeignKeyAction as MigrationForeignKeyAction, Index,
 };

--- a/src/models/frequency_limit.rs
+++ b/src/models/frequency_limit.rs
@@ -72,10 +72,14 @@ impl MigrationTrait for Migration {
                             .not_null(),
                     )
                     .col(MigrationColumnDef::new(Column::Count).unsigned().not_null())
-                    .col(MigrationColumnDef::new(Column::WindowEnd).timestamp())
+                    .col(
+                        MigrationColumnDef::new(Column::WindowEnd)
+                            .timestamp_with_time_zone()
+                            .null(),
+                    )
                     .col(
                         MigrationColumnDef::new(Column::UpdatedAt)
-                            .timestamp()
+                            .timestamp_with_time_zone()
                             .not_null()
                             .default(Expr::current_timestamp()),
                     )

--- a/src/models/rbac.rs
+++ b/src/models/rbac.rs
@@ -1,7 +1,9 @@
 use sea_orm::Set;
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
-use sea_orm_migration::schema::{big_integer, boolean, string, text_null, timestamp};
+use sea_orm_migration::schema::{
+    big_integer, boolean, string_len, text_null, timestamp_with_time_zone as timestamp,
+};
 use sea_orm_migration::sea_query::{ColumnDef, ForeignKeyAction};
 use serde::{Deserialize, Serialize};
 
@@ -343,8 +345,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         ColumnDef::new(Column::Name)
-                            .string()
-                            .char_len(100)
+                            .string_len(100)
                             .unique_key()
                             .not_null(),
                     )
@@ -368,8 +369,8 @@ impl MigrationTrait for Migration {
                             .primary_key(),
                     )
                     .col(big_integer(role_permission::Column::RoleId))
-                    .col(string(role_permission::Column::Resource).char_len(100))
-                    .col(string(role_permission::Column::Action).char_len(100))
+                    .col(string_len(role_permission::Column::Resource, 100))
+                    .col(string_len(role_permission::Column::Action, 100))
                     .foreign_key(
                         ForeignKey::create()
                             .from(role_permission::Entity, role_permission::Column::RoleId)

--- a/src/models/routing.rs
+++ b/src/models/routing.rs
@@ -1,7 +1,8 @@
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::schema::{
-    boolean, integer, json_null, string, string_null, text_null, timestamp, timestamp_null,
+    boolean, integer, json_null, string_len, string_len_null, text_null,
+    timestamp_with_time_zone as timestamp, timestamp_with_time_zone_null as timestamp_null,
 };
 use sea_orm_migration::sea_query::{ColumnDef, ForeignKeyAction as MigrationForeignKeyAction};
 use sea_query::Expr;
@@ -147,29 +148,27 @@ impl MigrationTrait for Migration {
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(string(Column::Name).char_len(160))
+                    .col(string_len(Column::Name, 160))
                     .col(text_null(Column::Description))
                     .col(
-                        string(Column::Direction)
-                            .char_len(32)
+                        string_len(Column::Direction, 32)
                             .default(RoutingDirection::default().as_str()),
                     )
                     .col(integer(Column::Priority).not_null().default(100))
                     .col(boolean(Column::IsActive).default(true))
                     .col(
-                        string(Column::SelectionStrategy)
-                            .char_len(32)
+                        string_len(Column::SelectionStrategy, 32)
                             .default(RoutingSelectionStrategy::default().as_str()),
                     )
-                    .col(string_null(Column::HashKey).char_len(120))
+                    .col(string_len_null(Column::HashKey, 120))
                     .col(ColumnDef::new(Column::SourceTrunkId).big_integer().null())
                     .col(ColumnDef::new(Column::DefaultTrunkId).big_integer().null())
-                    .col(string_null(Column::SourcePattern).char_len(160))
-                    .col(string_null(Column::DestinationPattern).char_len(160))
+                    .col(string_len_null(Column::SourcePattern, 160))
+                    .col(string_len_null(Column::DestinationPattern, 160))
                     .col(json_null(Column::HeaderFilters))
                     .col(json_null(Column::RewriteRules))
                     .col(json_null(Column::TargetTrunks))
-                    .col(string_null(Column::Owner).char_len(120))
+                    .col(string_len_null(Column::Owner, 120))
                     .col(json_null(Column::Notes))
                     .col(json_null(Column::Metadata))
                     .col(timestamp(Column::CreatedAt).default(Expr::current_timestamp()))

--- a/src/models/sip_trunk.rs
+++ b/src/models/sip_trunk.rs
@@ -1,8 +1,8 @@
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::schema::{
-    boolean, double_null, integer_null, json_null, string, string_null, text_null, timestamp,
-    timestamp_null,
+    boolean, double_null, integer_null, json_null, string_len, string_len_null, text_null,
+    timestamp_with_time_zone as timestamp, timestamp_with_time_zone_null as timestamp_null,
 };
 use sea_orm_migration::sea_query::ColumnDef;
 use sea_query::Expr;
@@ -146,30 +146,27 @@ impl MigrationTrait for Migration {
                             .primary_key()
                             .auto_increment(),
                     )
-                    .col(string(Column::Name).char_len(120))
-                    .col(string_null(Column::DisplayName).char_len(160))
-                    .col(string_null(Column::Carrier).char_len(160))
+                    .col(string_len(Column::Name, 120))
+                    .col(string_len_null(Column::DisplayName, 160))
+                    .col(string_len_null(Column::Carrier, 160))
                     .col(text_null(Column::Description))
                     .col(
-                        string(Column::Status)
-                            .char_len(32)
+                        string_len(Column::Status, 32)
                             .default(SipTrunkStatus::default().as_str()),
                     )
                     .col(
-                        string(Column::Direction)
-                            .char_len(32)
+                        string_len(Column::Direction, 32)
                             .default(SipTrunkDirection::default().as_str()),
                     )
-                    .col(string_null(Column::SipServer).char_len(160))
+                    .col(string_len_null(Column::SipServer, 160))
                     .col(
-                        string(Column::SipTransport)
-                            .char_len(16)
+                        string_len(Column::SipTransport, 16)
                             .default(SipTransport::default().as_str()),
                     )
-                    .col(string_null(Column::OutboundProxy).char_len(160))
-                    .col(string_null(Column::AuthUsername).char_len(160))
-                    .col(string_null(Column::AuthPassword).char_len(160))
-                    .col(string_null(Column::DefaultRouteLabel).char_len(160))
+                    .col(string_len_null(Column::OutboundProxy, 160))
+                    .col(string_len_null(Column::AuthUsername, 160))
+                    .col(string_len_null(Column::AuthPassword, 160))
+                    .col(string_len_null(Column::DefaultRouteLabel, 160))
                     .col(integer_null(Column::MaxCps))
                     .col(integer_null(Column::MaxConcurrent))
                     .col(integer_null(Column::MaxCallDuration))
@@ -180,8 +177,8 @@ impl MigrationTrait for Migration {
                     .col(json_null(Column::BillingSnapshot))
                     .col(json_null(Column::Analytics))
                     .col(json_null(Column::Tags))
-                    .col(string_null(Column::IncomingFromUserPrefix).char_len(160))
-                    .col(string_null(Column::IncomingToUserPrefix).char_len(160))
+                    .col(string_len_null(Column::IncomingFromUserPrefix, 160))
+                    .col(string_len_null(Column::IncomingToUserPrefix, 160))
                     .col(boolean(Column::IsActive).default(true))
                     .col(boolean(Column::RegisterEnabled).default(false))
                     .col(integer_null(Column::RegisterExpires))

--- a/src/models/system_notification.rs
+++ b/src/models/system_notification.rs
@@ -68,7 +68,7 @@ impl MigrationTrait for Migration {
                     )
                     .col(
                         MigrationColumnDef::new(Column::CreatedAt)
-                            .timestamp()
+                            .timestamp_with_time_zone()
                             .not_null()
                             .default(Expr::current_timestamp()),
                     )

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -9,7 +9,8 @@ use sea_orm::ActiveValue::Set;
 use sea_orm::entity::prelude::*;
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::schema::{
-    boolean, string, string_null, string_uniq, timestamp, timestamp_null,
+    boolean, string_len, string_len_null, string_len_uniq, timestamp_with_time_zone as timestamp,
+    timestamp_with_time_zone_null as timestamp_null,
 };
 use sea_orm_migration::sea_query::ColumnDef;
 use serde::Serialize;
@@ -148,21 +149,21 @@ impl MigrationTrait for Migration {
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(string_uniq(Column::Email).char_len(255))
-                    .col(string_uniq(Column::Username).char_len(100))
-                    .col(string(Column::PasswordHash).char_len(255))
-                    .col(string_null(Column::ResetToken).char_len(128))
+                    .col(string_len_uniq(Column::Email, 255))
+                    .col(string_len_uniq(Column::Username, 100))
+                    .col(string_len(Column::PasswordHash, 255))
+                    .col(string_len_null(Column::ResetToken, 128))
                     .col(timestamp_null(Column::ResetTokenExpires))
                     .col(timestamp_null(Column::LastLoginAt))
-                    .col(string_null(Column::LastLoginIp).char_len(128))
+                    .col(string_len_null(Column::LastLoginIp, 128))
                     .col(timestamp(Column::CreatedAt).default(Expr::current_timestamp()))
                     .col(timestamp(Column::UpdatedAt).default(Expr::current_timestamp()))
                     .col(boolean(Column::IsActive).default(true))
                     .col(boolean(Column::IsStaff).default(false))
                     .col(boolean(Column::IsSuperuser).default(false))
                     .col(boolean(Column::MfaEnabled).default(false))
-                    .col(string_null(Column::MfaSecret).char_len(64))
-                    .col(string(Column::AuthSource).char_len(32).default("local"))
+                    .col(string_len_null(Column::MfaSecret, 64))
+                    .col(string_len(Column::AuthSource, 32).default("local"))
                     .to_owned(),
             )
             .await?;

--- a/src/proxy/locator_db.rs
+++ b/src/proxy/locator_db.rs
@@ -3,9 +3,14 @@ use crate::call::Location;
 use anyhow::Result;
 use async_trait::async_trait;
 use rsipstack::transport::SipAddr;
-use sea_orm::{ActiveModelTrait, Database, QueryOrder, Set, entity::prelude::*};
+use sea_orm::{
+    ActiveModelTrait, Database, QueryOrder, Set, entity::prelude::*,
+};
 pub use sea_orm_migration::prelude::*;
-use sea_orm_migration::schema::{boolean, integer, pk_auto, string, string_null, timestamp};
+use sea_orm_migration::schema::{
+    big_integer, boolean, string_len, string_len_null, timestamp_with_time_zone as timestamp,
+};
+use sea_orm_migration::sea_query::ColumnDef as MigrationColumnDef;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
@@ -51,14 +56,19 @@ impl MigrationTrait for Migration {
                 Table::create()
                     .table(Entity)
                     .if_not_exists()
-                    .col(pk_auto(Column::Id))
-                    .col(string(Column::Aor).char_len(255).not_null())
-                    .col(integer(Column::Expires).not_null())
-                    .col(string(Column::Username).char_len(200).not_null())
-                    .col(string_null(Column::Realm).char_len(200))
-                    .col(string(Column::Destination).char_len(255).not_null())
-                    .col(string(Column::Transport).char_len(32).not_null())
-                    .col(integer(Column::LastModified).not_null())
+                    .col(
+                        MigrationColumnDef::new(Column::Id)
+                            .big_integer()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(string_len(Column::Aor, 255).not_null())
+                    .col(big_integer(Column::Expires).not_null())
+                    .col(string_len(Column::Username, 200).not_null())
+                    .col(string_len_null(Column::Realm, 200))
+                    .col(string_len(Column::Destination, 255).not_null())
+                    .col(string_len(Column::Transport, 32).not_null())
+                    .col(big_integer(Column::LastModified).not_null())
                     .col(
                         timestamp(Column::CreatedAt)
                             .not_null()
@@ -70,7 +80,7 @@ impl MigrationTrait for Migration {
                             .default(Expr::current_timestamp()),
                     )
                     .col(boolean(Column::SupportsWebrtc).not_null().default(false))
-                    .col(string_null(Column::UserAgent).char_len(255))
+                    .col(string_len_null(Column::UserAgent, 255))
                     .to_owned(),
             )
             .await?;


### PR DESCRIPTION
## Summary
- align SeaORM migration column definitions with model/runtime types for fresh PostgreSQL databases
- use BIGINT IDs/FKs where models expect i64, TIMESTAMPTZ where models expect DateTimeUtc, and variable-length strings/enums where values are variable
- add PostgreSQL support to the SeaORM dependency features and keep MySQL/SQLite model read/write behavior unchanged

## Compatibility Notes
- focused on fresh PostgreSQL compatibility; existing PostgreSQL repair/normalize migrations were removed per review scope
- existing MySQL schemas using CHAR/VARCHAR/TIMESTAMP continue to be read through the Rust model field types
- SQLite column affinity is not expected to be affected by these migration helper changes

## Validation
- cargo check
- previously verified against the existing MySQL 5.7 container clone with current models and old schema definitions

## Known Output
- cargo check reports the existing unused-method warning in src/proxy/proxy_call/media_state.rs