### PR TITLE
Fix E2E submodule checkout credentials

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
           - name: p2p-demo
             cmd: cargo test --test e2e_p2p_demo_test -- --nocapture
           - name: queue
-            cmd: cargo test --test e2e_queue_test --test e2e_queue_comprehensive_test -- --nocapture
+            cmd: cargo test --test e2e_queue_comprehensive_test -- --nocapture
           - name: conference
             cmd: cargo test --test e2e_conference_test -- --nocapture
           - name: wholesale
@@ -29,7 +29,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: false
+      - name: Configure CNB credentials
+        env:
+          CNB_USERNAME: ${{ secrets.CNB_USERNAME }}
+          CNB_TOKEN: ${{ secrets.CNB_TOKEN }}
+        run: |
+          test -n "$CNB_USERNAME" || { echo "CNB_USERNAME secret is required"; exit 1; }
+          test -n "$CNB_TOKEN" || { echo "CNB_TOKEN secret is required"; exit 1; }
+          git config --global credential.helper store
+          printf "protocol=https\nhost=cnb.cool\nusername=%s\npassword=%s\n\n" "$CNB_USERNAME" "$CNB_TOKEN" | git credential approve
+      - name: Checkout submodules
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --recursive --depth=1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: install sipbot
         run: cargo install sipbot || true


### PR DESCRIPTION
## Summary

- configure the E2E workflow to use `CNB_USERNAME` and `CNB_TOKEN` for `cnb.cool` submodule checkout
- switch `actions/checkout` to `submodules: false` and perform authenticated submodule checkout manually
- remove the stale `e2e_queue_test` target from the queue matrix command

## Why

The failed E2E run never reached `cargo test`; it failed during `actions/checkout` because GitHub's token cannot clone private `https://cnb.cool/miuda.ai/*` submodules.

## PR workflow behavior

`.github/workflows/e2e.yml` has `pull_request` targeting `main`, so this workflow should run for this PR. The CNB secrets should be available for same-repository PR branches, but not for forked PRs.

## Validation

- `git diff --cached --check`
- Existing local targeted e2e commands were run before this commit; p2p, conference, queue comprehensive, and wholesale targets completed locally. `actionlint` was not installed locally.
