### PR TITLE
Split E2E jobs by feature set

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,21 +11,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  e2e:
+  e2e-default:
+    name: e2e (default features)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test:
-          - name: p2p-comprehensive
-            cmd: cargo test --test e2e_p2p_comprehensive_test -- --nocapture
-          - name: p2p-demo
-            cmd: cargo test --test e2e_p2p_demo_test -- --nocapture
-          - name: queue
-            cmd: cargo test --test e2e_queue_comprehensive_test -- --nocapture
-          - name: conference
-            cmd: cargo test --test e2e_conference_test -- --nocapture
-          - name: wholesale
-            cmd: cargo test --features wholesale --test e2e_wholesale_test -- --nocapture
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: install sipbot
+        run: cargo install sipbot || true
+      - name: Run default E2E tests
+        run: cargo test --test e2e_p2p_comprehensive_test --test e2e_p2p_demo_test --test e2e_queue_comprehensive_test --test e2e_conference_test -- --nocapture
+        timeout-minutes: 10
+
+  e2e-wholesale:
+    name: e2e (wholesale)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,12 +39,13 @@ jobs:
           test -n "$CNB_TOKEN" || { echo "CNB_TOKEN secret is required"; exit 1; }
           git config --global credential.helper store
           printf "protocol=https\nhost=cnb.cool\nusername=%s\npassword=%s\n\n" "$CNB_USERNAME" "$CNB_TOKEN" | git credential approve
-      - name: Checkout submodules
+      - name: Checkout wholesale submodule
         run: |
-          git submodule sync --recursive
-          git submodule update --init --recursive --depth=1
+          git submodule sync --recursive src/addons/wholesale
+          git submodule update --init --recursive --depth=1 src/addons/wholesale
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: install sipbot
         run: cargo install sipbot || true
-      - run: ${{ matrix.test.cmd }}
+      - name: Run wholesale E2E tests
+        run: cargo test --features wholesale --test e2e_wholesale_test -- --nocapture
         timeout-minutes: 10

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,4 +47,4 @@ jobs:
       - name: install sipbot
         run: cargo install sipbot || true
       - run: ${{ matrix.test.cmd }}
-        timeout-minutes: 5
+        timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Run non-wholesale E2E targets together in one default-feature Cargo invocation.
- Keep wholesale E2E in a separate job with `--features wholesale`.
- Checkout only the wholesale submodule for the wholesale E2E job.
- Keep the E2E cargo step timeout at 10 minutes.

## Why
- The previous matrix ran five separate jobs, so each job rebuilt the project independently.
- Wholesale needs a different feature set, so it should stay separate from default-feature E2E.
- The wholesale job timed out because cold compile plus tests exceeded the previous 5-minute step timeout.

## Validation
- Parsed the workflow YAML locally.
- Checked Cargo supports repeated `--test` selectors.
- Did not run E2E locally.