### PR TITLE
Fix E2E rustls provider setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: install sipbot
-        run: cargo install sipbot || true
       - name: Run default E2E tests
         run: cargo test --test e2e_p2p_comprehensive_test --test e2e_p2p_demo_test --test e2e_queue_comprehensive_test --test e2e_conference_test -- --nocapture
         timeout-minutes: 10
@@ -44,8 +42,6 @@ jobs:
           git submodule sync --recursive src/addons/wholesale
           git submodule update --init --recursive --depth=1 src/addons/wholesale
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: install sipbot
-        run: cargo install sipbot || true
       - name: Run wholesale E2E tests
         run: cargo test --features wholesale --test e2e_wholesale_test -- --nocapture
         timeout-minutes: 10

--- a/src/call/app/app_context.rs
+++ b/src/call/app/app_context.rs
@@ -149,6 +149,8 @@ pub struct PendingQueuePlan {
 impl ApplicationContext {
     /// Create a new application context.
     pub fn new(db: DatabaseConnection, call_info: CallInfo, config: Arc<Config>) -> Self {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         Self {
             session_vars: Arc::new(RwLock::new(HashMap::new())),
             queue_name: Arc::new(RwLock::new(None)),


### PR DESCRIPTION
## Summary

- Remove the unused `cargo install sipbot || true` workflow steps; these Rust E2E tests use the `sipbot` dev-dependency with `default-features = false`, so the standalone binary install only pulled in ALSA/device features and hid a CI error.
- Install the rustls ring provider before `ApplicationContext` constructs its `reqwest::Client`, which fixes the integration-test panic from `rustls-no-provider`.

## Validation

- `cargo check --test e2e_queue_comprehensive_test`
- `cargo test --test e2e_queue_comprehensive_test test_queue_sequential_two_agents -- --nocapture`

Draft PR is intended to let GitHub Actions verify the full default and wholesale E2E workflows before merging.