### PR TITLE
Move rustls provider setup to entrypoints

### DIFF
--- a/src/bin/sipflow.rs
+++ b/src/bin/sipflow.rs
@@ -125,6 +125,10 @@ fn convert_packet_to_item(packet: Packet) -> (String, SipFlowItem) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let args = Args::parse();
 
     // Initialize tracing: try log file, fall back to stdout on permission error

--- a/src/call/app/app_context.rs
+++ b/src/call/app/app_context.rs
@@ -149,8 +149,6 @@ pub struct PendingQueuePlan {
 impl ApplicationContext {
     /// Create a new application context.
     pub fn new(db: DatabaseConnection, call_info: CallInfo, config: Arc<Config>) -> Self {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-
         Self {
             session_vars: Arc::new(RwLock::new(HashMap::new())),
             queue_name: Arc::new(RwLock::new(None)),

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -8,6 +8,13 @@
 // instead of littering individual items with attributes.
 #![allow(dead_code)]
 
+#[ctor::ctor(unsafe)]
+fn init_rustls_crypto_provider() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider for integration tests");
+}
+
 pub mod audio_verifier;
 pub mod cdr_verifier;
 pub mod rwi_collector;

--- a/tools/verify_i18n.rs
+++ b/tools/verify_i18n.rs
@@ -5,6 +5,10 @@ use std::env;
 use std::fs;
 
 fn main() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {


### PR DESCRIPTION
## Summary

- Move the rustls provider install out of `ApplicationContext::new()`.
- Install the provider directly in executable entrypoints that can construct rustls-backed clients.
- Add an integration-test binary initializer so E2E tests install the provider before PBX library code runs.
- Keep provider setup fail-fast with `expect(...)`.

## Validation

- `cargo check --bin rustpbx --bin sipflow --bin verify-i18n`
- `cargo test --test e2e_p2p_comprehensive_test --test e2e_p2p_demo_test --test e2e_queue_comprehensive_test --test e2e_conference_test -- --nocapture`
- `cargo test --features wholesale --test e2e_wholesale_test -- --nocapture`
- Searched captured E2E logs for `No rustls crypto provider`, `alsa-sys`, `failed to compile sipbot`, `panicked at`, and `background task panic`; no matches.

Draft PR is for CI confirmation before merging.