### PR TITLE
fix(console): stop coercing plain SIP queue targets into skill groups

### DIFF
--- a/src/addons/queue/templates/queue_detail.html
+++ b/src/addons/queue/templates/queue_detail.html
@@ -857,6 +857,18 @@ endblock %}
                     if (!target || typeof target !== 'object') {
                         return;
                     }
+                    // Only reconcile targets that are ACTUALLY skill groups.
+                    // `extractSkillGroupId` returns its input unchanged when there is no
+                    // `skill-group:` prefix, so without this guard a plain SIP target
+                    // (e.g. `sip:1000@localhost`) would be coerced into
+                    // `skill-group:sip:1000@localhost` and rendered as a skill-group
+                    // dropdown every time the form is (re)loaded.
+                    const isSkillGroup =
+                        (typeof target.uri === 'string' && /^skill(?:-|_)?group:/i.test(target.uri)) ||
+                        !!target.skill_group_id;
+                    if (!isSkillGroup) {
+                        return;
+                    }
                     const groupId = this.extractSkillGroupId(target.skill_group_id || target.uri);
                     if (!groupId) {
                         return;


### PR DESCRIPTION
When opening the queue detail form, `reconcileSkillGroupTargets()` calls `extractSkillGroupId()` on every dial target:

```js
const groupId = this.extractSkillGroupId(target.skill_group_id || target.uri);
if (!groupId) return;
target.skill_group_id = groupId;
target.uri = this.toSkillGroupUri(groupId); // adds "skill-group:" prefix
```

`extractSkillGroupId()` returns its input **unchanged** when there is no `skill-group:` prefix. So a plain SIP target like `sip:1000@localhost` is rewritten to `skill-group:sip:1000@localhost` and rendered as a skill-group dropdown on every (re)load — even though it was saved correctly to the DB.

This is especially confusing on deployments **without** the CC addon: `loadSkillGroups()` fetches `/cc/skill-groups`, gets a `404`, and the `res.ok ? res.json() : null` branch still flows into `.then(...)` which calls `reconcileSkillGroupTargets()`. The SIP target then renders as an unresolvable skill-group, and at call time the queue logs `No agent registry available to resolve custom target` and immediately falls through to the fallback.

### Fix
Guard the reconciliation so it only applies to targets that are *actually* skill groups (a `skill-group:` URI prefix or an explicit `skill_group_id`). Plain SIP targets are left untouched.

### Repro
1. Build without the CC addon (no skill-group API).
2. Create a queue with a sequential dial target `sip:1000@localhost`.
3. Reopen the queue in the console → the SIP target shows as a "Skill group" dropdown ("Select a skill group"), and inbound calls never ring the extension.

### After
The SIP target renders as a SIP URI field and rings the registered extension as configured.