### PR TITLE
fix(queue): route inbound queue calls through the callee-leg path (working two-way media + hangup)

### DIFF
--- a/src/proxy/data.rs
+++ b/src/proxy/data.rs
@@ -450,7 +450,17 @@ impl ProxyDataContext {
         } else {
             None
         };
-        let generated_entries = if let Some(ref info) = generated {
+        // When not regenerating from the DB (e.g. at startup), fall back to the
+        // previously generated routes file on disk if it exists. Without this,
+        // routes were not loaded on startup and an operator had to manually hit
+        // "reload routes" after every restart. Trunks and queues already do this.
+        let generated_path = if generated.is_none() {
+            resolve_generated_path(&config.routes_files, &default_dir, "routes.generated.toml")
+                .filter(|p| p.exists())
+        } else {
+            None
+        };
+        let mut generated_entries = if let Some(ref info) = generated {
             info.entries
         } else {
             0usize
@@ -483,6 +493,20 @@ impl ProxyDataContext {
             let (generated_routes, _) = load_routes_from_files(&generated_pattern)?;
             for route in generated_routes {
                 upsert_route(&mut routes, route);
+            }
+        } else if let Some(ref path) = generated_path {
+            info!(path = %path.display(), "loading previously generated routes file");
+            let generated_pattern = vec![path.to_string_lossy().to_string()];
+            match load_routes_from_files(&generated_pattern) {
+                Ok((generated_routes, _)) => {
+                    generated_entries = generated_routes.len();
+                    for route in generated_routes {
+                        upsert_route(&mut routes, route);
+                    }
+                }
+                Err(e) => {
+                    warn!("failed to load previously generated routes file: {}", e);
+                }
             }
         }
 

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -1,4 +1,3 @@
-use crate::call::app::PendingQueuePlan;
 use crate::call::app::{ApplicationContext, CallInfo};
 use crate::call::domain::{
     CallCommand, HangupCascade, HangupCommand, LegId, LegState, MediaPathMode, MediaRuntimeProfile,
@@ -11,7 +10,7 @@ use crate::call::runtime::{
     AppFactory, AppRuntime, AppRuntimeConfig, CommandResult, DefaultAppRuntime, ExecutionContext,
     MediaCapabilityCheck, SessionId,
 };
-use crate::call::{DialStrategy, Location};
+use crate::call::Location;
 use crate::models::call_record::extract_sip_username;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
@@ -3313,92 +3312,21 @@ impl SipSession {
                 }
 
                 DialplanFlow::Queue { plan, next } => {
-                    // Extract agents from plan
-                    let agents = match &plan.dial_strategy {
-                        Some(DialStrategy::Sequential(l)) => l.clone(),
-                        Some(DialStrategy::Parallel(l)) => l.clone(),
-                        None => {
-                            warn!("No dial strategy in queue plan");
-                            return self.execute_flow(next, callee_state_rx).await;
-                        }
-                    };
-
-                    if agents.is_empty() {
-                        warn!("No agents configured in queue plan");
+                    if plan.dial_strategy.is_none() {
+                        warn!("No dial strategy in queue plan");
                         return self.execute_flow(next, callee_state_rx).await;
                     }
 
-                    // Resolve custom targets (skill-groups → specific agents)
-                    let resolved_agents = self
-                        .resolve_custom_targets(agents, plan.acd_policy.as_deref())
-                        .await;
-
-                    // Enrich via queue_location_enricher if configured
-                    let resolved_agents =
-                        if let Some(enricher) = &self.server.queue_location_enricher {
-                            let caller_headers: Vec<rsipstack::sip::Header> = self
-                                .server_dialog
-                                .initial_request()
-                                .headers
-                                .iter()
-                                .cloned()
-                                .collect();
-                            enricher
-                                .enrich(
-                                    resolved_agents,
-                                    &crate::proxy::call::QueueEnrichContext {
-                                        session_id: &self.context.session_id.to_string(),
-                                        queue_name: &plan.queue_name,
-                                        caller_headers: &caller_headers,
-                                    },
-                                )
-                                .await
-                        } else {
-                            resolved_agents
-                        };
-
-                    let is_parallel = matches!(plan.dial_strategy, Some(DialStrategy::Parallel(_)));
-                    let agent_uris: Vec<String> = resolved_agents
-                        .iter()
-                        .map(|l| l.contact_raw.clone().unwrap_or_else(|| l.aor.to_string()))
-                        .collect();
-
-                    // Store resolved plan in context for the queue app factory
-                    if let Some(runtime) = self
-                        .app_runtime
-                        .as_any()
-                        .downcast_ref::<DefaultAppRuntime>()
-                    {
-                        *runtime.context.pending_queue.lock().unwrap() = Some(PendingQueuePlan {
-                            plan: plan.clone(),
-                            agent_uris,
-                            parallel: is_parallel,
-                        });
-                    }
-
-                    match self
-                        .app_runtime
-                        .start_app("queue", None, plan.accept_immediately)
-                        .await
-                    {
-                        Ok(()) => {
-                            self.start_caller_ingress_monitor_if_needed().await;
-                            // Inject dial_next_agent to kick off sequential agent dialing
-                            // (parallel mode auto-dials in on_enter)
-                            if !is_parallel {
-                                let _ = self.app_runtime.inject_event(serde_json::json!({
-                                    "type": "custom",
-                                    "name": "dial_next_agent",
-                                    "data": {},
-                                }));
-                            }
-                            Ok(())
-                        }
-                        Err(e) => {
-                            warn!(error = %e, "Queue: failed to start queue app, trying next flow");
-                            self.execute_flow(next, callee_state_rx).await
-                        }
-                    }
+                    // Run the queue through the proxy/callee-leg path. Agents are
+                    // dialed as the standard `callee` leg (via `try_single_target`
+                    // / `create_callee_track`), which gives working two-way
+                    // anchored media, hangup cascade, recording and codec
+                    // negotiation for free — the same machinery as a normal
+                    // answered call. The app-runtime queue (dynamic `LegAdd`
+                    // legs) is intentionally NOT used for inbound routing because
+                    // those legs are not wired into media forwarding or the call
+                    // lifecycle. (Transfer-to-queue already uses this path.)
+                    self.execute_queue(plan, callee_state_rx).await
                 }
                 DialplanFlow::Application {
                     app_name,

--- a/src/proxy/tests/mod.rs
+++ b/src/proxy/tests/mod.rs
@@ -28,6 +28,7 @@ mod test_dn_events_e2e;
 mod test_inbound_refer;
 mod test_ivr_queue_e2e;
 mod test_media_e2e;
+mod test_queue_media_e2e;
 mod test_rtp_e2e;
 mod test_session_hook_e2e;
 mod test_sip_info_dtmf_e2e;

--- a/src/proxy/tests/test_queue_media_e2e.rs
+++ b/src/proxy/tests/test_queue_media_e2e.rs
@@ -406,6 +406,61 @@ async fn test_queue_caller_answer_narrows_to_agent_codec() -> Result<()> {
     Ok(())
 }
 
+/// Bidirectional audio must also work when the caller is answered EARLY (the
+/// `accept_immediately` path, which routes the caller through the app media
+/// bridge). This guards the early-answer/app-bridge path itself.
+///
+/// NOTE: production showed ~87% caller->agent loss specifically with HOLD MUSIC
+/// (file playback through the bridge, then the stop/transition when the agent
+/// connects). This test does NOT reproduce that — the early-answer app bridge
+/// alone is clean here — so the hold-music transition is the suspect. A faithful
+/// repro needs hold-music file playback in the harness (test-infra gap).
+#[tokio::test]
+async fn test_queue_early_answer_bidirectional_rtp() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let ctx = QueueMediaTestCtx::setup_with_config(queue_proxy_config_with(Vec::new(), true)).await?;
+
+    let caller_sdp = pcmu_sdp("127.0.0.1", ctx.caller_receiver.port().unwrap());
+    let agent_sdp = pcmu_sdp("127.0.0.1", ctx.agent_receiver.port().unwrap());
+
+    let (caller_id, _agent_id, agent_offer) =
+        ctx.establish_queue_call(caller_sdp, agent_sdp).await?;
+
+    let caller_answer_sdp = ctx
+        .caller_ua
+        .get_negotiated_answer_sdp(&caller_id)
+        .await
+        .ok_or_else(|| anyhow!("No answer SDP on caller side"))?;
+    let agent_target = extract_media_endpoint(&agent_offer)
+        .ok_or_else(|| anyhow!("Failed to parse agent-side endpoint"))?;
+    let caller_target = extract_media_endpoint(&caller_answer_sdp)
+        .ok_or_else(|| anyhow!("Failed to parse caller-side endpoint"))?;
+
+    let (caller_stats, agent_stats) = ctx
+        .exchange_rtp(caller_target, agent_target, 0, 2000)
+        .await?;
+    info!(
+        caller_received = caller_stats.packets_received,
+        agent_received = agent_stats.packets_received,
+        "Early-answer queue RTP exchange complete"
+    );
+
+    assert!(
+        agent_stats.packets_received > 0,
+        "Agent should receive RTP from caller even with early-answer/app-bridge (got 0) \
+         — this is the ~87%-loss garbled-agent-audio regression"
+    );
+    assert!(
+        caller_stats.packets_received > 0,
+        "Caller should receive RTP from agent with early-answer/app-bridge (got 0)"
+    );
+
+    ctx.caller_ua.hangup(&caller_id).await?;
+    ctx.server.stop();
+    Ok(())
+}
+
 /// When the agent hangs up, the caller's call must be torn down too (the
 /// hangup must cascade through the queue bridge). The dynamic-leg path failed
 /// to propagate the agent BYE, leaving the caller stuck in a live call.

--- a/src/proxy/tests/test_queue_media_e2e.rs
+++ b/src/proxy/tests/test_queue_media_e2e.rs
@@ -22,7 +22,7 @@
 
 use super::e2e_test_server::E2eTestServer;
 use super::rtp_utils::{RtpReceiver, RtpSender, RtpStats, extract_media_endpoint};
-use super::test_helpers::pcmu_sdp;
+use super::test_helpers::{build_sdp, pcma_sdp, pcmu_sdp};
 use super::test_ua::{TestUa, TestUaEvent};
 use crate::config::{MediaProxyMode, ProxyConfig};
 use crate::proxy::routing::{
@@ -40,12 +40,21 @@ use tracing::info;
 /// Build a ProxyConfig with a single queue "support" whose only agent is the
 /// registered user `bob`, plus a route that sends calls to `support` into it.
 fn queue_proxy_config() -> ProxyConfig {
+    queue_proxy_config_with(Vec::new(), false)
+}
+
+fn queue_proxy_config_with(audio_codecs: Vec<String>, accept_immediately: bool) -> ProxyConfig {
     let mut config = ProxyConfig {
         media_proxy: MediaProxyMode::All,
         // Match the E2E media test harness: disable RTP latching so the proxy
         // sends to the SDP-advertised receiver ports (the test's RtpReceivers)
         // rather than latching onto the RtpSenders' source ports.
         enable_latching: false,
+        audio_codecs: if audio_codecs.is_empty() {
+            None
+        } else {
+            Some(audio_codecs)
+        },
         ..Default::default()
     };
 
@@ -60,10 +69,7 @@ fn queue_proxy_config() -> ProxyConfig {
             wait_timeout_secs: Some(10),
             ..Default::default()
         },
-        // Do NOT answer the caller up front — this is the production-relevant
-        // path (caller answered only when the agent connects), and the one that
-        // exercised the early-media / HaveLocalOffer bug.
-        accept_immediately: false,
+        accept_immediately,
         ..Default::default()
     };
     config.queues.insert("support".to_string(), queue_config);
@@ -99,7 +105,11 @@ struct QueueMediaTestCtx {
 
 impl QueueMediaTestCtx {
     async fn setup() -> Result<Self> {
-        let server = Arc::new(E2eTestServer::start_with_config(queue_proxy_config()).await?);
+        Self::setup_with_config(queue_proxy_config()).await
+    }
+
+    async fn setup_with_config(config: ProxyConfig) -> Result<Self> {
+        let server = Arc::new(E2eTestServer::start_with_config(config).await?);
 
         // alice = caller, bob = the queue's agent. Both register so the queue
         // can resolve bob's contact via the locator.
@@ -287,6 +297,108 @@ async fn test_queue_call_bidirectional_rtp() -> Result<()> {
         caller_stats.payload_types.contains(&0),
         "Caller should receive PCMU (PT 0) from agent, got {:?}",
         caller_stats.payload_types
+    );
+
+    ctx.caller_ua.hangup(&caller_id).await?;
+    ctx.server.stop();
+    Ok(())
+}
+
+/// Symmetric to the agent-hangup case: when the CALLER hangs up, the agent's
+/// call must be torn down too. (NOTE: this exercises the UDP path; the
+/// TLS-specific variant — where a TLS callee advertises a Contact without
+/// `transport=TLS` and the cascade BYE wrongly goes out over UDP — cannot be
+/// reproduced here because TestUa only does UDP signaling. That fix needs SIP/TLS
+/// test infra; this guards the cascade direction itself.)
+#[tokio::test]
+async fn test_queue_caller_hangup_ends_agent_call() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let ctx = QueueMediaTestCtx::setup().await?;
+    let caller_sdp = pcmu_sdp("127.0.0.1", ctx.caller_receiver.port().unwrap());
+    let agent_sdp = pcmu_sdp("127.0.0.1", ctx.agent_receiver.port().unwrap());
+
+    let (caller_id, agent_id, _agent_offer) =
+        ctx.establish_queue_call(caller_sdp, agent_sdp).await?;
+    info!(%caller_id, %agent_id, "Queue call connected; caller will hang up");
+
+    ctx.caller_ua.hangup(&caller_id).await?;
+
+    for _ in 0..50 {
+        let events = ctx.agent_ua.process_dialog_events().await?;
+        if events
+            .iter()
+            .any(|e| matches!(e, TestUaEvent::CallTerminated(id) if id == &agent_id))
+        {
+            info!("Agent call terminated after caller hangup (cascade OK)");
+            ctx.server.stop();
+            return Ok(());
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    Err(anyhow!(
+        "Agent call did not terminate after caller hung up (caller->agent hangup cascade broken)"
+    ))
+}
+
+/// When the caller offers multiple codecs but the agent negotiates a single one
+/// (PCMA), the proxy's answer to the caller MUST end up consistent with that
+/// codec. If it leaves PCMU in the caller answer, the caller may send PCMU which
+/// is then relayed to a PCMA-only agent without transcoding — producing garbled
+/// / choppy audio (observed in production with a Twilio caller offering PCMU/PCMA
+/// and a PCMA-only Yealink agent).
+///
+/// KNOWN-FAILING / documented repro: when the caller is answered EARLY (hold
+/// music, or accept_immediately) using the full allowed codec set, the answer is
+/// never narrowed/renegotiated to the codec the agent later picks. The proper
+/// fix is to either narrow the early caller answer to a single codec or
+/// renegotiate (re-INVITE) the caller once the agent's codec is known.
+/// Operational workaround in the meantime: pin `audio_codecs` to a single codec.
+/// Remove `#[ignore]` when the proxy narrows/renegotiates correctly.
+#[ignore = "documents the early-answer codec-mismatch bug; fix = narrow/renegotiate caller codec"]
+#[tokio::test]
+async fn test_queue_caller_answer_narrows_to_agent_codec() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    // Reproduce the production config: multiple allowed codecs. The bug is that
+    // the caller answer is built from the allowed set instead of being narrowed
+    // to the codec the agent actually negotiated.
+    // accept_immediately=true answers the caller early (like hold music does in
+    // production) using the full allowed codec set, before the agent picks a
+    // single codec — the condition under which the caller answer fails to narrow.
+    let ctx = QueueMediaTestCtx::setup_with_config(queue_proxy_config_with(
+        vec!["pcma".to_string(), "pcmu".to_string(), "g722".to_string()],
+        true,
+    ))
+    .await?;
+
+    // Caller offers PCMU + PCMA; agent answers PCMA only.
+    let caller_sdp = build_sdp(
+        "127.0.0.1",
+        ctx.caller_receiver.port().unwrap(),
+        &[(0, "PCMU/8000"), (8, "PCMA/8000"), (101, "telephone-event/8000")],
+    );
+    let agent_sdp = pcma_sdp("127.0.0.1", ctx.agent_receiver.port().unwrap());
+
+    let (caller_id, _agent_id, _agent_offer) =
+        ctx.establish_queue_call(caller_sdp, agent_sdp).await?;
+
+    let caller_answer = ctx
+        .caller_ua
+        .get_negotiated_answer_sdp(&caller_id)
+        .await
+        .ok_or_else(|| anyhow!("No answer SDP on caller side"))?;
+    info!(%caller_answer, "Caller answer SDP");
+
+    assert!(
+        caller_answer.to_uppercase().contains("PCMA"),
+        "caller answer should offer PCMA (the agent's codec): {caller_answer}"
+    );
+    assert!(
+        !caller_answer.to_uppercase().contains("PCMU"),
+        "caller answer must NOT include PCMU when the agent negotiated PCMA-only — \
+         the caller could send PCMU and be relayed unconverted to a PCMA-only agent \
+         (garbled audio): {caller_answer}"
     );
 
     ctx.caller_ua.hangup(&caller_id).await?;

--- a/src/proxy/tests/test_queue_media_e2e.rs
+++ b/src/proxy/tests/test_queue_media_e2e.rs
@@ -1,0 +1,322 @@
+//! Queue Media E2E Test
+//!
+//! Verifies that a call routed into a **queue** and answered by an agent has
+//! working **bidirectional** RTP through the proxy in anchored
+//! (`media_proxy = all`) mode.
+//!
+//! This exercises the app-runtime queue path (inbound route → `queue` action →
+//! `app_runtime.start_app("queue")`), which dials agents as *dynamically-added
+//! legs* (`LegAdd` / `initiate_sip_leg`) rather than the fixed callee leg. That
+//! path is where a whole class of media bugs lived undetected, because the
+//! existing queue tests only asserted **signaling** (an agent received the
+//! INVITE) and never that **audio actually flows both ways** once the agent
+//! answers. Concretely, this test guards against:
+//!
+//! - early-media (183) consuming the leg's `HaveLocalOffer` so the final 200 OK
+//!   answer fails to apply, leaving the agent leg on the wrong codec/endpoint
+//!   and producing **no agent→caller audio**;
+//! - dynamic legs never being wired into media forwarding at all.
+//!
+//! The single assertion that matters — and that no prior queue test made — is
+//! that **both** the caller and the agent receive RTP packets.
+
+use super::e2e_test_server::E2eTestServer;
+use super::rtp_utils::{RtpReceiver, RtpSender, RtpStats, extract_media_endpoint};
+use super::test_helpers::pcmu_sdp;
+use super::test_ua::{TestUa, TestUaEvent};
+use crate::config::{MediaProxyMode, ProxyConfig};
+use crate::proxy::routing::{
+    MatchConditions, RouteAction, RouteQueueConfig, RouteQueueStrategyConfig,
+    RouteQueueTargetConfig, RouteRule,
+};
+use anyhow::{Result, anyhow};
+use rsipstack::dialog::DialogId;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::info;
+
+/// Build a ProxyConfig with a single queue "support" whose only agent is the
+/// registered user `bob`, plus a route that sends calls to `support` into it.
+fn queue_proxy_config() -> ProxyConfig {
+    let mut config = ProxyConfig {
+        media_proxy: MediaProxyMode::All,
+        // Match the E2E media test harness: disable RTP latching so the proxy
+        // sends to the SDP-advertised receiver ports (the test's RtpReceivers)
+        // rather than latching onto the RtpSenders' source ports.
+        enable_latching: false,
+        ..Default::default()
+    };
+
+    // Queue "support" → dial agent bob (resolved via the locator at call time).
+    let queue_config = RouteQueueConfig {
+        name: Some("support".to_string()),
+        strategy: RouteQueueStrategyConfig {
+            targets: vec![RouteQueueTargetConfig {
+                uri: "sip:bob@127.0.0.1".to_string(),
+                label: Some("Support Agent".to_string()),
+            }],
+            wait_timeout_secs: Some(10),
+            ..Default::default()
+        },
+        // Do NOT answer the caller up front — this is the production-relevant
+        // path (caller answered only when the agent connects), and the one that
+        // exercised the early-media / HaveLocalOffer bug.
+        accept_immediately: false,
+        ..Default::default()
+    };
+    config.queues.insert("support".to_string(), queue_config);
+
+    // Route: dial "support" → queue "support".
+    let queue_route = RouteRule {
+        name: "route_to_support".to_string(),
+        priority: 10,
+        match_conditions: MatchConditions {
+            to_user: Some("support".to_string()),
+            ..Default::default()
+        },
+        action: RouteAction {
+            queue: Some("support".to_string()),
+            auto_answer: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    config.routes = Some(vec![queue_route]);
+    config
+}
+
+struct QueueMediaTestCtx {
+    server: Arc<E2eTestServer>,
+    caller_ua: TestUa,
+    agent_ua: TestUa,
+    caller_sender: RtpSender,
+    caller_receiver: RtpReceiver,
+    agent_sender: RtpSender,
+    agent_receiver: RtpReceiver,
+}
+
+impl QueueMediaTestCtx {
+    async fn setup() -> Result<Self> {
+        let server = Arc::new(E2eTestServer::start_with_config(queue_proxy_config()).await?);
+
+        // alice = caller, bob = the queue's agent. Both register so the queue
+        // can resolve bob's contact via the locator.
+        let caller_ua = server.create_ua("alice").await?;
+        let agent_ua = server.create_ua("bob").await?;
+
+        sleep(Duration::from_millis(100)).await;
+
+        let caller_sender = RtpSender::bind().await?;
+        let caller_receiver = RtpReceiver::bind(0).await?;
+        let agent_sender = RtpSender::bind().await?;
+        let agent_receiver = RtpReceiver::bind(0).await?;
+
+        Ok(Self {
+            server,
+            caller_ua,
+            agent_ua,
+            caller_sender,
+            caller_receiver,
+            agent_sender,
+            agent_receiver,
+        })
+    }
+
+    /// Caller dials the queue ("support"); the queue hunts the agent (bob), who
+    /// answers. Returns (caller_dialog_id, agent_dialog_id, agent_offer_sdp).
+    async fn establish_queue_call(
+        &self,
+        caller_sdp: String,
+        agent_sdp: String,
+    ) -> Result<(DialogId, DialogId, String)> {
+        let caller = Arc::new(self.caller_ua.clone());
+        let caller_handle =
+            crate::utils::spawn(async move { caller.make_call("support", Some(caller_sdp)).await });
+
+        // The agent leg is dialed by the queue; wait for bob's INVITE and answer.
+        let mut agent: Option<(DialogId, String)> = None;
+        for _ in 0..100 {
+            let events = self.agent_ua.process_dialog_events().await?;
+            for event in events {
+                if let TestUaEvent::IncomingCall(id, offer) = event {
+                    self.agent_ua.answer_call(&id, Some(agent_sdp.clone())).await?;
+                    info!("Agent answered queue call");
+                    agent = Some((id, offer.unwrap_or_default()));
+                    break;
+                }
+            }
+            if agent.is_some() {
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        let (agent_id, agent_offer) =
+            agent.ok_or_else(|| anyhow!("Agent never received INVITE from queue"))?;
+
+        let caller_id = tokio::time::timeout(Duration::from_secs(8), caller_handle)
+            .await
+            .map_err(|_| anyhow!("Caller timed out waiting for queue connect"))?
+            .map_err(|e| anyhow!("Caller task join error: {}", e))?
+            .map_err(|e| anyhow!("Queue call failed: {}", e))?;
+
+        Ok((caller_id, agent_id, agent_offer))
+    }
+
+    /// Poll the caller's dialog events until its call is terminated, or fail.
+    async fn wait_for_caller_terminated(&self, caller_id: &DialogId, secs: u64) -> Result<()> {
+        for _ in 0..(secs * 10) {
+            let events = self.caller_ua.process_dialog_events().await?;
+            for event in events {
+                if let TestUaEvent::CallTerminated(id) = event {
+                    if &id == caller_id {
+                        return Ok(());
+                    }
+                }
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+        Err(anyhow!(
+            "Caller call did not terminate after agent hung up (hangup cascade broken)"
+        ))
+    }
+
+    async fn exchange_rtp(
+        &self,
+        caller_target: SocketAddr,
+        agent_target: SocketAddr,
+        payload_type: u8,
+        duration_ms: u64,
+    ) -> Result<(RtpStats, RtpStats)> {
+        use super::rtp_utils::RtpPacket;
+
+        let packet_interval_ms: u64 = 20;
+        let packet_count = (duration_ms / packet_interval_ms) as usize;
+
+        let caller_packets = RtpPacket::create_sequence(
+            packet_count, 1000, 50000, 0xA1A1A1A1, payload_type, 160, 160,
+        );
+        let agent_packets = RtpPacket::create_sequence(
+            packet_count, 2000, 60000, 0xB2B2B2B2, payload_type, 160, 160,
+        );
+
+        self.caller_receiver.start_receiving();
+        self.agent_receiver.start_receiving();
+
+        self.caller_sender
+            .start_sending(agent_target, caller_packets, packet_interval_ms);
+        self.agent_sender
+            .start_sending(caller_target, agent_packets, packet_interval_ms);
+
+        sleep(Duration::from_millis(duration_ms + 500)).await;
+
+        self.caller_sender.stop();
+        self.agent_sender.stop();
+        sleep(Duration::from_millis(200)).await;
+
+        Ok((
+            self.caller_receiver.get_stats().await,
+            self.agent_receiver.get_stats().await,
+        ))
+    }
+}
+
+/// A call routed through a queue and answered by an agent must have working
+/// bidirectional RTP through the proxy in anchored mode.
+#[tokio::test]
+async fn test_queue_call_bidirectional_rtp() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let ctx = QueueMediaTestCtx::setup().await?;
+
+    let caller_port = ctx.caller_receiver.port().unwrap();
+    let agent_port = ctx.agent_receiver.port().unwrap();
+
+    let caller_sdp = pcmu_sdp("127.0.0.1", caller_port);
+    let agent_sdp = pcmu_sdp("127.0.0.1", agent_port);
+
+    // 1. Caller dials the queue; agent answers.
+    let (caller_id, _agent_id, agent_offer) =
+        ctx.establish_queue_call(caller_sdp, agent_sdp).await?;
+    info!(%caller_id, "Queue call connected to agent");
+
+    // 2. Resolve the proxy-anchored RTP endpoints for both legs.
+    let caller_answer_sdp = ctx
+        .caller_ua
+        .get_negotiated_answer_sdp(&caller_id)
+        .await
+        .ok_or_else(|| anyhow!("No answer SDP on caller side"))?;
+
+    let agent_target = extract_media_endpoint(&agent_offer)
+        .ok_or_else(|| anyhow!("Failed to parse agent-side proxy media endpoint"))?;
+    let caller_target = extract_media_endpoint(&caller_answer_sdp)
+        .ok_or_else(|| anyhow!("Failed to parse caller-side proxy media endpoint"))?;
+
+    info!(%caller_target, %agent_target, "Anchored RTP endpoints resolved");
+
+    // 3. Exchange RTP for ~2s (PCMU).
+    let (caller_stats, agent_stats) = ctx
+        .exchange_rtp(caller_target, agent_target, 0, 2000)
+        .await?;
+
+    info!(
+        caller_received = caller_stats.packets_received,
+        agent_received = agent_stats.packets_received,
+        "Queue RTP exchange complete"
+    );
+
+    // 4. The assertions that matter: audio flows BOTH ways.
+    assert!(
+        agent_stats.packets_received > 0,
+        "Agent should receive RTP from caller through the queue bridge (got 0)"
+    );
+    assert!(
+        caller_stats.packets_received > 0,
+        "Caller should receive RTP from the agent through the queue bridge (got 0) \
+         — this is the regression that produced one-way (caller-only) audio"
+    );
+
+    assert!(
+        agent_stats.payload_types.contains(&0),
+        "Agent should receive PCMU (PT 0), got {:?}",
+        agent_stats.payload_types
+    );
+    assert!(
+        caller_stats.payload_types.contains(&0),
+        "Caller should receive PCMU (PT 0) from agent, got {:?}",
+        caller_stats.payload_types
+    );
+
+    ctx.caller_ua.hangup(&caller_id).await?;
+    ctx.server.stop();
+    Ok(())
+}
+
+/// When the agent hangs up, the caller's call must be torn down too (the
+/// hangup must cascade through the queue bridge). The dynamic-leg path failed
+/// to propagate the agent BYE, leaving the caller stuck in a live call.
+#[tokio::test]
+async fn test_queue_agent_hangup_ends_caller_call() -> Result<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let ctx = QueueMediaTestCtx::setup().await?;
+
+    let caller_sdp = pcmu_sdp("127.0.0.1", ctx.caller_receiver.port().unwrap());
+    let agent_sdp = pcmu_sdp("127.0.0.1", ctx.agent_receiver.port().unwrap());
+
+    let (caller_id, agent_id, _agent_offer) =
+        ctx.establish_queue_call(caller_sdp, agent_sdp).await?;
+    info!(%caller_id, %agent_id, "Queue call connected; agent will hang up");
+
+    // Agent hangs up.
+    ctx.agent_ua.hangup(&agent_id).await?;
+
+    // The caller's call must terminate as a result.
+    ctx.wait_for_caller_terminated(&caller_id, 5).await?;
+    info!("Caller call terminated after agent hangup (cascade OK)");
+
+    ctx.server.stop();
+    Ok(())
+}


### PR DESCRIPTION
Inbound calls routed to a queue went through the **app-runtime `QueueApp`**, which dials agents as dynamically-added legs (`LegAdd` / `initiate_sip_leg`). Those legs are **not wired into anchored media forwarding or the call lifecycle**, so a connected queue call had:

- **no agent→caller audio** (only the caller side was bridged/recorded), and
- **no hangup cascade** (agent hanging up left the caller in a live call).

## Fix
Route `DialplanFlow::Queue` through **`execute_queue`** — the same path already used for transfer-to-queue. It dials agents as the standard `callee` leg (`try_single_target` / `create_callee_track`), which provides two-way anchored media, hangup cascade, recording and codec negotiation for free, identical to a normal answered call. The app-runtime `QueueApp` remains for its unit-tested state machine but is no longer on the inbound media path.

Verified end-to-end against a real Twilio trunk + TLS Yealink agent: route → ring → ringback (180 relayed) → answer → clean two-way PCMA audio.

## Guardrail: e2e harness (the gap that let this ship)
Existing queue tests only asserted **signaling** (an agent received the INVITE), never that audio flows both ways or that a hangup tears the call down. This PR adds `test_queue_media_e2e`:

- `test_queue_call_bidirectional_rtp` — call into queue (anchored media), agent answers, assert **both** caller and agent receive RTP.
- `test_queue_caller_hangup_ends_agent_call` / `test_queue_agent_hangup_ends_caller_call` — hangup cascades both directions.
- `test_queue_early_answer_bidirectional_rtp` — audio works on the `accept_immediately` / app-bridge path too.
- `test_queue_caller_answer_narrows_to_agent_codec` (`#[ignore]`) — documented repro of an early-answer codec-mismatch bug (caller answered with multiple codecs is never narrowed to the agent's single codec → garbled audio). Operational workaround: pin a single codec.

All four active tests **fail on the old dynamic-leg path and pass on the callee-leg path**.

## Also included
`fix(routing): load generated routes file on startup` — `reload_routes(false)` (startup) never loaded the previously generated `routes.generated.toml`, so the route table was empty after every restart until a manual reload. Trunks and queues already fall back to their generated file; this mirrors that for routes.

## Known follow-ups (documented inline)
- TLS callee whose Contact omits `transport=TLS`: the cascade BYE egresses over UDP → 408 → callee not torn down. Needs SIP/TLS test infra to reproduce before fixing.
- Hold-music file playback degrades caller→agent audio on transition; needs file-playback test infra.
- Queue fallback still uses REFER (porting dial+bridge is a follow-up).