### PR TITLE
Allow compiler warnings in E2E builds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
       - name: Run default E2E tests
         run: cargo test --test e2e_p2p_comprehensive_test --test e2e_p2p_demo_test --test e2e_queue_comprehensive_test --test e2e_conference_test -- --nocapture
         timeout-minutes: 10
@@ -43,6 +45,8 @@ jobs:
           git submodule sync --recursive src/addons/wholesale
           git submodule update --init --recursive --depth=1 src/addons/wholesale
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
       - name: Run wholesale E2E tests
         run: cargo test --features wholesale --test e2e_wholesale_test -- --nocapture
         timeout-minutes: 10


### PR DESCRIPTION
## Summary

- leave `RUSTFLAGS` unset in both E2E jobs
- keep compiler warnings visible without promoting them to build errors

## Root cause

`actions-rust-lang/setup-rust-toolchain@v1` defaults `rustflags` to `-D warnings`. The default-feature and wholesale E2E builds therefore failed on existing `dead_code` warnings before their tests could run.

## Impact

Both E2E jobs can compile and execute despite non-fatal warnings. This does not address the separate wholesale submodule checkout failure caused by the referenced commit being unavailable from the submodule remote.

## Validation

- `git diff --check`
- workflow YAML parsed successfully
