### PR TITLE
Fix wholesale E2E feature set

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           rustflags: ""
       - name: Run wholesale E2E tests
-        run: cargo test --no-default-features --features wholesale --test e2e_wholesale_test -- --nocapture
+        run: cargo test --no-default-features --features wholesale,console,addon-observability --test e2e_wholesale_test -- --nocapture
         timeout-minutes: 20


### PR DESCRIPTION
## What changed

- Keep the wholesale E2E job on `--no-default-features`.
- Enable the minimal additional features required by the wholesale code path: `console` and `addon-observability`.

## Why

The wholesale addon imports console handlers and localization directly. The console metrics handler also references the observability addon, so `wholesale` alone does not compile when default features are disabled. The broader `commerce` feature is not required for wholesale runtime load/reload and would compile unrelated commercial addons.

## Impact

The wholesale E2E build avoids unrelated default features while retaining the console and observability dependencies it needs.

## Validation

- `cargo check --no-default-features --features wholesale,console,addon-observability --test e2e_wholesale_test`
- `git diff --check`

Local E2E tests were not run; the draft PR is intended to validate the GitHub Actions workflow.
