### PR TITLE
Restore ability to disable the UDP listener

### DIFF
--- a/docs/config/02-proxy-core.md
+++ b/docs/config/02-proxy-core.md
@@ -13,6 +13,8 @@ addr = "0.0.0.0"
 udp_port = 5060
 # Multiple UDP ports (e.g., for multi-tenant or port range binding)
 # udp_ports = [5060, 5062, 5064]
+# Omit both udp_port and udp_ports to disable UDP listening.
+# Port 0 requests an OS-assigned ephemeral port; it does not disable UDP.
 tcp_port = 5060
 
 # Encrypted SIP (SIPS)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1084,8 +1084,7 @@ impl ProxyConfig {
     }
 
     pub fn all_udp_ports(&self) -> Vec<u16> {
-        let primary = self.udp_port.unwrap_or(5060);
-        let mut ports = vec![primary];
+        let mut ports = self.udp_port.into_iter().collect::<Vec<_>>();
         if let Some(extra) = &self.udp_ports {
             for p in extra {
                 if !ports.contains(p) {
@@ -1352,6 +1351,46 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_all_udp_ports_preserves_default_primary_port() {
+        let config = ProxyConfig::default();
+
+        assert_eq!(config.all_udp_ports(), vec![5060]);
+    }
+
+    #[test]
+    fn test_all_udp_ports_is_empty_when_udp_configuration_is_omitted() {
+        let config: ProxyConfig = toml::from_str(
+            r#"
+            addr = "::"
+            tls_port = 5061
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.udp_port, None);
+        assert_eq!(config.udp_ports, None);
+        assert!(config.all_udp_ports().is_empty());
+    }
+
+    #[test]
+    fn test_all_udp_ports_uses_explicit_additional_ports_without_primary() {
+        let mut config = ProxyConfig::default();
+        config.udp_port = None;
+        config.udp_ports = Some(vec![5062, 5064, 5062]);
+
+        assert_eq!(config.all_udp_ports(), vec![5062, 5064]);
+    }
+
+    #[test]
+    fn test_all_udp_ports_combines_primary_and_unique_additional_ports() {
+        let mut config = ProxyConfig::default();
+        config.udp_port = Some(5060);
+        config.udp_ports = Some(vec![5060, 5062, 5064, 5062]);
+
+        assert_eq!(config.all_udp_ports(), vec![5060, 5062, 5064]);
+    }
 
     #[test]
     fn test_callrecord_max_concurrent_is_shared_config() {


### PR DESCRIPTION
Restores the ability to disable the UDP listeners.

This is important because when you are trying to host a server which you only intend to listen on TCP or on TLS, a UDP listener will still be created (either on 5060 if your config omits `udp_port`, or on a random port if you set `udp_port=0`), and this UDP listener gets used when creating a `Contact` header to send to clients causing them not to send future SIP messages over the existing TLS connection.

Previously you could disable the UDP listener, but this ability was seemingly removed when adding the ability to listen on multiple UDP ports in 534333b615f8d0b6589fbff28ba7e167a955ca12.