### PR TITLE
Configure CA bundle for outbound SIP/TLS

### DIFF
--- a/docs/config/02-proxy-core.md
+++ b/docs/config/02-proxy-core.md
@@ -22,6 +22,8 @@ tls_port = 5061
 # Uses proxy-level ssl_* configs (if not set, falls back to top-level ssl_*)
 ssl_certificate = "./certs/fullchain.pem"
 ssl_private_key = "./certs/privkey.pem"
+# PEM bundle used to validate certificates on outbound SIP/TLS connections
+tls_ca_certificates = "/etc/ssl/certs/ca-certificates.crt"
 
 # WebRTC (SIP over WebSocket)
 ws_port = 8089

--- a/src/callrecord/sipflow_upload.rs
+++ b/src/callrecord/sipflow_upload.rs
@@ -513,6 +513,7 @@ mod tests {
     use super::*;
     use crate::sipflow::{SipFlowBackend, SipFlowItem, SipFlowMediaStats};
     use chrono::{DateTime, Local};
+    use std::borrow::Cow;
 
     struct MockBackend {
         media: Vec<u8>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -663,6 +663,7 @@ pub struct ProxyConfig {
     pub t1x64_timer: Option<u64>,
     pub ssl_private_key: Option<String>,
     pub ssl_certificate: Option<String>,
+    pub tls_ca_certificates: Option<String>,
     pub udp_port: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub udp_ports: Option<Vec<u16>>,
@@ -1131,6 +1132,7 @@ impl Default for ProxyConfig {
             t1x64_timer: None,
             ssl_private_key: None,
             ssl_certificate: None,
+            tls_ca_certificates: None,
             udp_port: Some(5060),
             udp_ports: None,
             tcp_port: None,
@@ -1390,6 +1392,23 @@ mod tests {
         config.udp_ports = Some(vec![5060, 5062, 5064, 5062]);
 
         assert_eq!(config.all_udp_ports(), vec![5060, 5062, 5064]);
+    }
+
+    #[test]
+    fn test_proxy_tls_ca_certificates_path_is_parsed() {
+        let config: ProxyConfig = toml::from_str(
+            r#"
+            addr = "0.0.0.0"
+            tls_port = 5061
+            tls_ca_certificates = "/etc/ssl/certs/ca-certificates.crt"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.tls_ca_certificates.as_deref(),
+            Some("/etc/ssl/certs/ca-certificates.crt")
+        );
     }
 
     #[test]

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -494,6 +494,26 @@ impl SipServerBuilder {
         #[cfg(unix)]
         log_rlimit_nofile().await;
         let transport_layer = TransportLayer::new(cancel_token.clone());
+        if let Some(ca_path) = config.tls_ca_certificates.as_deref()
+            && !ca_path.trim().is_empty()
+        {
+            let ca_path = ca_path.trim();
+            let ca_certs = tokio::fs::read(ca_path).await.map_err(|e| {
+                anyhow!(
+                    "failed to read outbound SIP/TLS CA certificates {}: {}",
+                    ca_path,
+                    e
+                )
+            })?;
+            transport_layer.set_tls_config(TlsConfig {
+                ca_certs: Some(ca_certs),
+                ..Default::default()
+            });
+            info!(
+                path = ca_path,
+                "configured outbound SIP/TLS CA certificates"
+            );
+        }
         // Clone of TLS listener for hot-reload support (initialized inside if !self.no_bind block)
         let mut tls_listener_clone: Option<rsipstack::transport::TlsListenerConnection> = None;
 


### PR DESCRIPTION
## Summary

- add `[proxy].tls_ca_certificates` for a PEM CA bundle
- install the configured bundle on the transport layer used by outbound SIP/TLS connections
- document the setting and cover config parsing with a focused unit test
- restore a missing `Cow` import that blocked library test compilation

## Root cause

Outbound TLS connections inherited an empty `rsipstack::TlsConfig`, so the Rustls root store had no trusted issuers. RustPBX also never called `TransportLayer::set_tls_config`, leaving no way to supply CA roots.

## Impact

Operators can configure a public or private CA bundle while retaining hostname/SNI validation. An unreadable configured bundle fails startup with the path and error; invalid or insufficient roots continue to fail the TLS handshake.

Closes #235.

## Validation

- `cargo check --no-default-features --lib`
- `cargo test --no-default-features --lib config::tests::test_proxy_tls_ca_certificates_path_is_parsed` (1 passed)
- `git diff --check`

Local end-to-end tests were not used.
