### PR TITLE
fix(proxy): reply 200 to BYE when dialog is already gone

### DIFF
--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -1678,7 +1678,14 @@ impl CallModule {
         let mut dialog = match self.inner.dialog_layer.get_dialog(&dialog_id) {
             Some(dialog) => dialog,
             None => {
-                debug!(%dialog_id, method=%tx.original.method, "dialog not found for message");
+                // Peers retransmit BYE if we already tore the dialog down. Answer
+                // with 200 so endpoints clear; other methods stay silent at debug.
+                if matches!(tx.original.method, rsipstack::sip::Method::Bye) {
+                    info!(%dialog_id, "BYE with no matching dialog; replying 200 so peer clears");
+                    let _ = tx.reply(rsipstack::sip::StatusCode::OK).await;
+                } else {
+                    debug!(%dialog_id, method=%tx.original.method, "dialog not found for message");
+                }
                 return Ok(());
             }
         };


### PR DESCRIPTION
## Summary
- When an in-dialog `BYE` arrives for a `DialogId` no longer in `DialogLayer`, reply **200 OK** instead of dropping the request with no response.
- Stops ATAs (observed: Grandstream HT812) from staying off-hook and retransmitting BYE after the B2BUA already tore the dialog down.

## Context
Closes #242

## Test plan
- [ ] Establish call, hang up from PBX side so dialog is removed, send BYE from peer → peer receives 200 and clears
- [ ] Normal in-dialog BYE with live dialog still answered by dialog handler (unchanged)
- [ ] Unmatched non-BYE mid-dialog request still no response (debug log only)