### PR TITLE
Derive Contact URI from Inbound Transaction

### DIFF
--- a/src/proxy/call.rs
+++ b/src/proxy/call.rs
@@ -1314,7 +1314,11 @@ impl CallModule {
         let mut dialplan = dialplan;
 
         if dialplan.caller_contact.is_none()
-            && let Some(contact_uri) = self.inner.server.default_contact_uri()
+            && let Some(contact_uri) = self
+                .inner
+                .server
+                .contact_uri_for_transaction(tx)
+                .or_else(|| self.inner.server.default_contact_uri())
         {
             let contact = rsipstack::sip::typed::Contact {
                 display_name: None,

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -1115,6 +1115,7 @@ impl SipSession {
             .caller_contact
             .as_ref()
             .map(|c| c.uri.clone())
+            .or_else(|| server.contact_uri_for_transaction(tx))
             .or_else(|| server.default_contact_uri());
 
         let (state_tx, state_rx) = mpsc::unbounded_channel();

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -40,8 +40,8 @@ use rsipstack::{
         transaction::Transaction,
     },
     transport::{
-        TcpListenerConnection, TlsConfig, TlsListenerConnection, TransportLayer,
-        WebSocketListenerConnection, udp::UdpConnection,
+        SipAddr, SipConnection, TcpListenerConnection, TlsConfig, TlsListenerConnection,
+        TransportLayer, WebSocketListenerConnection, udp::UdpConnection,
     },
 };
 
@@ -1341,22 +1341,30 @@ impl Drop for SipServerInner {
 impl SipServerInner {
     pub fn default_contact_uri(&self) -> Option<rsipstack::sip::Uri> {
         let addr = self.endpoint.get_addrs().first()?.clone();
-        let mut params = Vec::new();
-        if let Some(transport) = addr.r#type
-            && !matches!(transport, Transport::Udp)
-        {
-            params.push(Param::Transport(transport));
+        Some(build_contact_uri(&self.contact_username, &addr, None))
+    }
+
+    /// Build a Contact URI for a response to an inbound SIP transaction.
+    ///
+    /// Stream connections retain the advertised local address of the listener
+    /// that accepted the request, so using the transaction connection keeps the
+    /// Contact scheme, transport, host, and port on that same listener.
+    pub fn contact_uri_for_transaction(&self, tx: &Transaction) -> Option<rsipstack::sip::Uri> {
+        let connection = tx.connection.as_ref()?;
+
+        // RustPBX's HTTP WebSocket adapter represents a client with a synthetic
+        // ChannelConnection whose address is the remote client's address. It
+        // must never be advertised as the server's Contact. Preserve the
+        // existing endpoint-level fallback for that adapter.
+        if matches!(connection, SipConnection::Channel(_)) {
+            return None;
         }
-        Some(rsipstack::sip::Uri {
-            scheme: addr.r#type.map(|t| t.sip_scheme()),
-            auth: Some(Auth {
-                user: self.contact_username.clone(),
-                password: None,
-            }),
-            host_with_port: addr.addr,
-            params,
-            ..Default::default()
-        })
+
+        Some(build_contact_uri(
+            &self.contact_username,
+            connection.get_addr(),
+            Some(connection.transport()),
+        ))
     }
 
     pub fn default_media_config(&self) -> MediaConfig {
@@ -1559,6 +1567,30 @@ impl SipServerInner {
     }
 }
 
+fn build_contact_uri(
+    contact_username: &str,
+    addr: &SipAddr,
+    fallback_transport: Option<Transport>,
+) -> rsipstack::sip::Uri {
+    let transport = addr.r#type.or(fallback_transport);
+    let mut params = Vec::new();
+    if let Some(transport) = transport
+        && !matches!(transport, Transport::Udp)
+    {
+        params.push(Param::Transport(transport));
+    }
+    rsipstack::sip::Uri {
+        scheme: transport.map(|t| t.sip_scheme()),
+        auth: Some(Auth {
+            user: contact_username.to_string(),
+            password: None,
+        }),
+        host_with_port: addr.addr.clone(),
+        params,
+        ..Default::default()
+    }
+}
+
 struct CompositeMessageInspector {
     inspectors: Vec<Box<dyn MessageInspector>>,
 }
@@ -1605,4 +1637,50 @@ async fn log_rlimit_nofile() {
         }
     }
     info!("RLIMIT_NOFILE: current fd count ~{count}");
+}
+
+#[cfg(test)]
+mod contact_uri_tests {
+    use super::*;
+    use rsipstack::sip::HostWithPort;
+
+    fn sip_addr(value: &str, transport: Option<Transport>) -> SipAddr {
+        SipAddr {
+            r#type: transport,
+            addr: HostWithPort::try_from(value).expect("valid SIP address"),
+        }
+    }
+
+    #[test]
+    fn contact_uri_uses_tls_listener_address_and_transport() {
+        let addr = sip_addr("[2001:db8::20]:5061", Some(Transport::Tls));
+
+        let uri = build_contact_uri("rustpbx", &addr, Some(Transport::Udp));
+
+        assert_eq!(
+            uri.to_string(),
+            "sips:rustpbx@[2001:db8::20]:5061;transport=TLS"
+        );
+    }
+
+    #[test]
+    fn contact_uri_falls_back_to_connection_transport() {
+        let addr = sip_addr("[2001:db8::20]:5061", None);
+
+        let uri = build_contact_uri("rustpbx", &addr, Some(Transport::Tls));
+
+        assert_eq!(
+            uri.to_string(),
+            "sips:rustpbx@[2001:db8::20]:5061;transport=TLS"
+        );
+    }
+
+    #[test]
+    fn udp_contact_uri_does_not_add_transport_parameter() {
+        let addr = sip_addr("192.0.2.20:5060", Some(Transport::Udp));
+
+        let uri = build_contact_uri("rustpbx", &addr, None);
+
+        assert_eq!(uri.to_string(), "sip:rustpbx@192.0.2.20:5060");
+    }
 }


### PR DESCRIPTION
Currently the `Contact:` URI sent to clients is always set to the `default_contact_uri`, but this breaks if we have multiple listeners and the one handling the connection isn't the default listener (i.e. just the first one in the list (usually UDP)).

To fix that, this PR finds the listener which actually received the SIP message and uses that to create a `Contact:` header pointing at that listener.

Note: Currently, websockets connections are affected by this problem just like the other `ListenerConnection`s, but I guess it's assumed that a websocket client will always send responses over the websocket no matter what the `Contact:` header says.  To keep this patch small, it preserves that behavior, but a followup fix should probably address that so websocket clients capable of using other transports don't reach out to the default listener when they could just keep talking over their websocket connection.