### PR TITLE
fix: honor step provider retry config

### DIFF
--- a/docs/ivr_step_protocol_en.md
+++ b/docs/ivr_step_protocol_en.md
@@ -435,7 +435,7 @@ When an IVR is entered via `transfer` (with `target="ivr:other_ivr"`) or `jump_i
 
 | Scenario | Behavior |
 |----------|----------|
-| **Provider HTTP timeout** (per‑request timeout = `retry.timeout_ms`, default 1000ms) | Retry, up to `retry.max_retries` (default 3). Between retries: 100ms sleep. |
+| **Provider HTTP timeout** (per‑request timeout = `retry.timeout_ms`, default 1000ms) | Retry, up to `retry.max_retries` (default 3). Between retries: wait `retry.delay_ms` (default 100ms). |
 | **Provider returns 5xx** | Same as timeout — retry loop. |
 | **All retries exhausted** | Execute `retry.fallback` (default: `{"type":"hangup","prompt":"sounds/error.wav"}`). |
 | **Provider returns invalid JSON / unknown action type** | Record trace error → play `sounds/error.wav` → hangup. |
@@ -467,6 +467,7 @@ When a `prompt` action contains `tts_text` but no TTS service is configured:
   "retry": {
     "max_retries": 5,
     "timeout_ms": 2000,
+    "delay_ms": 250,
     "fallback": { "type": "transfer", "target": "operator" }
   },
   "name": "my-step-ivr"
@@ -479,6 +480,7 @@ When a `prompt` action contains `tts_text` but no TTS service is configured:
 | `headers` | `Map<string,string>` | `{}` | Custom HTTP headers sent on every provider call |
 | `retry.max_retries` | u32 | `3` | Max retry attempts |
 | `retry.timeout_ms` | u64 | `1000` | Per‑request timeout in **milliseconds** |
+| `retry.delay_ms` | u64 | `100` | Delay between failed attempts in **milliseconds** |
 | `retry.fallback` | ActionNode | `{"type":"hangup","prompt":"sounds/error.wav"}` | Action to execute when all retries fail |
 | `name` | string | `"step_ivr"` | Display name for tracing |
 
@@ -492,7 +494,8 @@ When a `prompt` action contains `tts_text` but no TTS service is configured:
   "headers": { "Authorization": "Bearer token123" },
   "retry": {
     "max_retries": 3,
-    "timeout_ms": 1000
+    "timeout_ms": 1000,
+    "delay_ms": 100
   }
 }
 ```

--- a/src/call/app/ivr/executor.rs
+++ b/src/call/app/ivr/executor.rs
@@ -3285,6 +3285,7 @@ mod tests {
             StepProvider::new(format!("http://{addr}/ivr/step")).with_retry(RetryConfig {
                 max_retries: 1,
                 timeout_ms: 15_000,
+                retry_delay_ms: 100,
                 fallback_action: None,
             });
         let ctx = make_test_context();

--- a/src/call/app/ivr/provider.rs
+++ b/src/call/app/ivr/provider.rs
@@ -1,5 +1,7 @@
 use crate::call::app::ivr::common::SessionData;
-use crate::call::app::ivr::config::{ActionNode, EntryAction, IvrDefinition, MenuNode};
+use crate::call::app::ivr::config::{
+    ActionNode, EntryAction, IvrDefinition, IvrProviderConfig, MenuNode,
+};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -274,6 +276,7 @@ impl From<&str> for EndReason {
 pub struct RetryConfig {
     pub max_retries: u32,
     pub timeout_ms: u64,
+    pub retry_delay_ms: u64,
     pub fallback_action: Option<ActionNode>,
 }
 
@@ -282,6 +285,7 @@ impl Default for RetryConfig {
         Self {
             max_retries: 3,
             timeout_ms: 1000,
+            retry_delay_ms: 100,
             fallback_action: Some(ActionNode {
                 action: EntryAction::Hangup {
                     prompt: Some("sounds/error.wav".into()),
@@ -293,6 +297,17 @@ impl Default for RetryConfig {
                 step_name: None,
                 extra: None,
             }),
+        }
+    }
+}
+
+impl From<&IvrProviderConfig> for RetryConfig {
+    fn from(config: &IvrProviderConfig) -> Self {
+        Self {
+            max_retries: config.max_retries,
+            timeout_ms: config.timeout_secs.saturating_mul(1000),
+            retry_delay_ms: config.retry_delay_ms,
+            fallback_action: None,
         }
     }
 }
@@ -559,7 +574,7 @@ impl ActionProvider for StepProvider {
                 }
             }
             if attempt < self.retry.max_retries - 1 {
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                tokio::time::sleep(Duration::from_millis(self.retry.retry_delay_ms)).await;
             }
         }
         // All retries exhausted → fallback

--- a/src/proxy/proxy_call/sip_session.rs
+++ b/src/proxy/proxy_call/sip_session.rs
@@ -343,8 +343,11 @@ impl AppFactory for BuiltinAppFactory {
                         let timeout = retry
                             .get("timeout_ms")
                             .and_then(|v| v.as_u64())
-                            .or_else(|| retry.get("delay_ms").and_then(|v| v.as_u64()))
                             .unwrap_or(1000);
+                        let retry_delay = retry
+                            .get("delay_ms")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(100);
                         let fallback = serde_json::from_value(
                             retry.get("fallback").cloned().unwrap_or(serde_json::json!({
                                 "type": "hangup",
@@ -355,6 +358,7 @@ impl AppFactory for BuiltinAppFactory {
                         provider = provider.with_retry(crate::call::app::ivr::RetryConfig {
                             max_retries,
                             timeout_ms: timeout,
+                            retry_delay_ms: retry_delay,
                             fallback_action: fallback,
                         });
                     }
@@ -438,11 +442,9 @@ impl AppFactory for BuiltinAppFactory {
                         for (k, v) in &provider_cfg.headers {
                             provider.add_header(k, v);
                         }
-                        provider = provider.with_retry(crate::call::app::ivr::RetryConfig {
-                            max_retries: provider_cfg.max_retries,
-                            timeout_ms: provider_cfg.retry_delay_ms,
-                            fallback_action: None,
-                        });
+                        provider = provider.with_retry(
+                            crate::call::app::ivr::RetryConfig::from(provider_cfg),
+                        );
 
                         let mut app =
                             crate::call::app::ivr::StepIvrApp::with_provider(Box::new(provider));

--- a/tests/step_provider_retry_config_test.rs
+++ b/tests/step_provider_retry_config_test.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+use rustpbx::call::app::ivr::config::EntryAction;
+use rustpbx::call::app::ivr::config::IvrProviderConfig;
+use rustpbx::call::app::ivr::{
+    ActionProvider, ProviderContext, ProviderEvent, RetryConfig, StepProvider,
+};
+
+#[test]
+fn step_provider_uses_configured_timeout_and_retry_delay() {
+    let config = IvrProviderConfig {
+        url: "http://127.0.0.1:28080/ivr/step".into(),
+        headers: HashMap::new(),
+        max_retries: 3,
+        retry_delay_ms: 250,
+        timeout_secs: 10,
+    };
+
+    let retry = RetryConfig::from(&config);
+
+    assert_eq!(retry.max_retries, 3);
+    assert_eq!(retry.timeout_ms, 10_000);
+    assert_eq!(retry.retry_delay_ms, 250);
+    assert!(retry.fallback_action.is_none());
+}
+
+async fn record_attempt(
+    State(request_times): State<Arc<Mutex<Vec<Instant>>>>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let attempt = {
+        let mut request_times = request_times.lock().unwrap();
+        request_times.push(Instant::now());
+        request_times.len()
+    };
+
+    if attempt == 1 {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "retry"})),
+        )
+    } else {
+        (StatusCode::OK, Json(serde_json::json!({"type": "hangup"})))
+    }
+}
+
+#[tokio::test]
+async fn step_provider_waits_for_configured_retry_delay() {
+    let request_times = Arc::new(Mutex::new(Vec::new()));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/ivr/step", post(record_attempt))
+        .with_state(Arc::clone(&request_times));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let provider = StepProvider::new(format!("http://{addr}/ivr/step")).with_retry(RetryConfig {
+        max_retries: 2,
+        timeout_ms: 1_000,
+        retry_delay_ms: 250,
+        fallback_action: None,
+    });
+    let context = ProviderContext {
+        session_id: "retry-delay-test".into(),
+        caller: "1001".into(),
+        callee: "2000".into(),
+        direction: "inbound".into(),
+        tenant_id: None,
+        ivr_id: None,
+        variables: HashMap::new(),
+        sip_headers: None,
+        event: Some(ProviderEvent::SessionStart),
+        route_name: None,
+        route_headers: None,
+        custom_data: None,
+        step_start_time: None,
+        step_end_time: None,
+        step_duration_ms: None,
+        step_index: None,
+        transferred_from: None,
+    };
+
+    let action = tokio::time::timeout(Duration::from_secs(2), provider.next_action(context))
+        .await
+        .expect("provider retry loop timed out")
+        .expect("second provider attempt should succeed");
+    server.abort();
+
+    assert!(matches!(action.action, EntryAction::Hangup { .. }));
+    let request_times = request_times.lock().unwrap();
+    assert_eq!(request_times.len(), 2);
+    let observed_delay = request_times[1].duration_since(request_times[0]);
+    assert!(
+        observed_delay >= Duration::from_millis(200),
+        "configured 250ms retry delay was not honored; observed {observed_delay:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fix Step IVR provider retry configuration handling.

- Convert `timeout_secs` to milliseconds
- Apply the configured retry delay instead of a hard-coded delay
- Keep request timeout and retry delay as separate settings
- Document `retry.delay_ms`
- Add configuration mapping and runtime retry regression tests

## Problem

The TOML provider configuration previously used `retry_delay_ms` as the
request timeout and ignored `timeout_secs`. The retry loop also always
waited 100 ms instead of honoring the configured delay.

## Testing

- `cargo test --test step_provider_retry_config_test`
- `rustfmt --edition 2024 --check tests/step_provider_retry_config_test.rs`
- `git diff --check upstream/main`
