### PR TITLE
fix: pin rustrtc and preserve CC agent state during partial updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ rsipstack = "0.5.24"
 hex = { version = "0.4.3", optional = true }
 #rsipstack = { path = "../rsipstack" }
 audio-codec = "0.3.40"
-rustrtc = "0.3.111"
+rustrtc = "=0.3.111"
 reqwest = { version = "0.13.4", default-features = false, features = [
     "json",
     "stream",


### PR DESCRIPTION
## Summary

Fix clean builds and preserve CC agent state during partial updates.

- Pin `rustrtc` to version `0.3.111` to prevent incompatible patch upgrades
- Preserve endpoint mode and other unchanged agent fields during partial updates
- Avoid unnecessary core agent writes for extra-only updates
- Replace agent extras transactionally to prevent data loss
- Propagate extra persistence failures to the API response
- Add regression tests for partial updates and failed extra replacement

## Problem

The non-exact `rustrtc` dependency allowed Cargo to resolve newer compatible
versions, which caused clean builds to fail.

CC agent updates could also overwrite existing state when optional fields were
omitted. Extra replacement deleted the existing values before inserting the new
ones without a transaction, so an insertion failure could lose the previous
data while the API still returned success.
