### PR TITLE
Stabilize IVR tracing, SIP dialog routing, and audio downloads

### DIFF
--- a/crates/rustpbx-media/src/audio_source.rs
+++ b/crates/rustpbx-media/src/audio_source.rs
@@ -1,10 +1,14 @@
 use anyhow::{Result, anyhow};
 use audio_codec::{BoxedResampler, CodecType, create_decoder};
 use std::path::Path;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::wav_reader::{WavFormat, WavReader, format_issues};
+
+const AUDIO_DOWNLOAD_RETRY_BACKOFF: Duration = Duration::from_millis(10);
+const AUDIO_DOWNLOAD_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Return the path portion of a URL/file string, stripping any query string
 /// (e.g. `?expire=...&signature=...`) so extension detection on a signed/
@@ -79,19 +83,71 @@ impl FileAudioSource {
     }
 
     async fn download_bytes(url: &str) -> Result<Vec<u8>> {
-        let response = rustpbx_http_util::shared_keepalive_client()
+        Self::download_bytes_with_timeout(url, AUDIO_DOWNLOAD_ATTEMPT_TIMEOUT).await
+    }
+
+    async fn download_bytes_with_timeout(url: &str, attempt_timeout: Duration) -> Result<Vec<u8>> {
+        let initial_error = match rustpbx_http_util::shared_keepalive_client()
             .get(url)
+            .timeout(attempt_timeout)
             .send()
             .await
-            .map_err(|e| anyhow!("Failed to download audio file: {}", e))?;
+        {
+            Ok(response) => {
+                if !response.status().is_success() {
+                    return Err(anyhow!("HTTP error: {}", response.status()));
+                }
+                match response.bytes().await {
+                    Ok(bytes) => return Ok(bytes.to_vec()),
+                    Err(error) => anyhow!("Failed to read response body: {}", error.without_url()),
+                }
+            }
+            Err(error) => anyhow!("Audio download request failed: {}", error.without_url()),
+        };
+
+        warn!(
+            error = %initial_error,
+            "Audio download failed on pooled connection; retrying with a fresh connection"
+        );
+        tokio::time::sleep(AUDIO_DOWNLOAD_RETRY_BACKOFF).await;
+        let fresh_client =
+            rustpbx_http_util::build_keepalive_client(None, None).map_err(|retry_error| {
+                anyhow!(
+                    "Failed to download audio file: initial request: {}; fresh client: {}",
+                    initial_error,
+                    retry_error
+                )
+            })?;
+        let response = fresh_client
+            .get(url)
+            .timeout(attempt_timeout)
+            .send()
+            .await
+            .map_err(|error| {
+                anyhow!(
+                    "Failed to download audio file: initial request: {}; fresh retry: {}",
+                    initial_error,
+                    error.without_url()
+                )
+            })?;
         if !response.status().is_success() {
-            return Err(anyhow!("HTTP error: {}", response.status()));
+            return Err(anyhow!(
+                "Failed to download audio file: initial request: {}; fresh retry: HTTP error: {}",
+                initial_error,
+                response.status()
+            ));
         }
-        let bytes = response
+        response
             .bytes()
             .await
-            .map_err(|e| anyhow!("Failed to read response body: {}", e))?;
-        Ok(bytes.to_vec())
+            .map(|bytes| bytes.to_vec())
+            .map_err(|error| {
+                anyhow!(
+                    "Failed to download audio file: initial request: {}; fresh retry: {}",
+                    initial_error,
+                    error.without_url()
+                )
+            })
     }
 }
 
@@ -1148,6 +1204,317 @@ mod tests {
             }
         });
         format!("http://{addr}")
+    }
+
+    fn serve_stale_keepalive_then_fresh(body: Vec<u8>) -> (String, std::thread::JoinHandle<bool>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            use std::time::{Duration, Instant};
+
+            fn read_request(stream: &mut std::net::TcpStream) {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .expect("set read timeout");
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let read = stream.read(&mut buf).expect("read request");
+                    assert!(read > 0, "client closed before sending request");
+                    request.extend_from_slice(&buf[..read]);
+                }
+            }
+
+            fn write_response(stream: &mut std::net::TcpStream, body: &[u8], connection: &str) {
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: {connection}\r\n\r\n",
+                    body.len()
+                );
+                stream.write_all(header.as_bytes()).expect("write headers");
+                stream.write_all(body).expect("write body");
+                stream.flush().expect("flush response");
+            }
+
+            let (mut pooled, _) = listener.accept().expect("accept pooled connection");
+            read_request(&mut pooled);
+            write_response(&mut pooled, &body, "keep-alive");
+
+            read_request(&mut pooled);
+            drop(pooled);
+
+            listener.set_nonblocking(true).expect("set nonblocking");
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut fresh, _)) => {
+                        read_request(&mut fresh);
+                        write_response(&mut fresh, &body, "close");
+                        return true;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept fresh connection: {error}"),
+                }
+            }
+            false
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn serve_partial_body_then_fresh(body: Vec<u8>) -> (String, std::thread::JoinHandle<bool>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            use std::time::{Duration, Instant};
+
+            fn read_request(stream: &mut std::net::TcpStream) {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .expect("set read timeout");
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let read = stream.read(&mut buf).expect("read request");
+                    assert!(read > 0, "client closed before sending request");
+                    request.extend_from_slice(&buf[..read]);
+                }
+            }
+
+            let (mut pooled, _) = listener.accept().expect("accept pooled connection");
+            read_request(&mut pooled);
+            let seed_header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                body.len()
+            );
+            pooled
+                .write_all(seed_header.as_bytes())
+                .expect("write seed headers");
+            pooled.write_all(&body).expect("write seed body");
+            pooled.flush().expect("flush seed response");
+
+            read_request(&mut pooled);
+            let partial_header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            pooled
+                .write_all(partial_header.as_bytes())
+                .expect("write partial headers");
+            pooled
+                .write_all(&body[..body.len() / 2])
+                .expect("write partial body");
+            pooled.flush().expect("flush partial response");
+            drop(pooled);
+
+            listener.set_nonblocking(true).expect("set nonblocking");
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut fresh, _)) => {
+                        read_request(&mut fresh);
+                        let header = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        fresh
+                            .write_all(header.as_bytes())
+                            .expect("write fresh headers");
+                        fresh.write_all(&body).expect("write fresh body");
+                        fresh.flush().expect("flush fresh response");
+                        return true;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept fresh connection: {error}"),
+                }
+            }
+            false
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn serve_http_error() -> (String, std::thread::JoinHandle<usize>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request);
+            stream
+                .write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("write error response");
+            stream.flush().expect("flush error response");
+            1
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    fn serve_silent_then_fresh(body: Vec<u8>) -> (String, std::thread::JoinHandle<bool>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = std::thread::spawn(move || {
+            use std::io::{Read, Write};
+            use std::time::{Duration, Instant};
+
+            fn read_request(stream: &mut std::net::TcpStream) {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(1)))
+                    .expect("set read timeout");
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let read = stream.read(&mut buf).expect("read request");
+                    assert!(read > 0, "client closed before sending request");
+                    request.extend_from_slice(&buf[..read]);
+                }
+            }
+
+            let (mut pooled, _) = listener.accept().expect("accept pooled connection");
+            read_request(&mut pooled);
+            let seed_header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n",
+                body.len()
+            );
+            pooled
+                .write_all(seed_header.as_bytes())
+                .expect("write seed headers");
+            pooled.write_all(&body).expect("write seed body");
+            pooled.flush().expect("flush seed response");
+
+            read_request(&mut pooled);
+            listener.set_nonblocking(true).expect("set nonblocking");
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut fresh, _)) => {
+                        read_request(&mut fresh);
+                        let header = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            body.len()
+                        );
+                        fresh
+                            .write_all(header.as_bytes())
+                            .expect("write fresh headers");
+                        fresh.write_all(&body).expect("write fresh body");
+                        fresh.flush().expect("flush fresh response");
+                        drop(pooled);
+                        return true;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept fresh connection: {error}"),
+                }
+            }
+            false
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    #[tokio::test]
+    async fn test_audio_download_retries_transport_failure_on_fresh_connection() {
+        let pcm = sine_pcm(800, 8000, 440.0, 16_000.0);
+        let wav = build_wav(0x0001, 8000, 1, 16, &pcm_bytes(&pcm));
+        let (base, server) = serve_stale_keepalive_then_fresh(wav);
+        let url = format!("{base}/prompt.wav");
+
+        FileAudioSource::new(url.clone(), false)
+            .await
+            .expect("seed pooled connection");
+        let second = FileAudioSource::new(url, false).await;
+        let used_fresh_connection = server.join().expect("join HTTP server");
+
+        let mut source = second.expect("retry transport failure on a fresh connection");
+        assert!(used_fresh_connection, "retry must use a fresh connection");
+        let mut decoded = vec![0i16; pcm.len()];
+        assert_eq!(source.read_samples(&mut decoded), pcm.len());
+        assert_eq!(decoded, pcm);
+    }
+
+    #[tokio::test]
+    async fn test_audio_download_retries_partial_body_on_fresh_connection() {
+        let pcm = sine_pcm(800, 8000, 440.0, 16_000.0);
+        let wav = build_wav(0x0001, 8000, 1, 16, &pcm_bytes(&pcm));
+        let (base, server) = serve_partial_body_then_fresh(wav);
+        let url = format!("{base}/prompt.wav");
+
+        FileAudioSource::new(url.clone(), false)
+            .await
+            .expect("seed pooled connection");
+        let result = FileAudioSource::new(url, false).await;
+        let used_fresh_connection = server.join().expect("join HTTP server");
+
+        let mut source = result.expect("partial body should retry on fresh connection");
+        assert!(used_fresh_connection, "retry must use a fresh connection");
+        let mut decoded = vec![0i16; pcm.len()];
+        assert_eq!(source.read_samples(&mut decoded), pcm.len());
+        assert_eq!(decoded, pcm);
+    }
+
+    #[tokio::test]
+    async fn test_audio_download_does_not_retry_http_error() {
+        let (base, server) = serve_http_error();
+        let result = FileAudioSource::new(format!("{base}/prompt.wav"), false).await;
+        let requests = server.join().expect("join HTTP server");
+
+        let error = match result {
+            Ok(_) => panic!("HTTP error should fail without retry"),
+            Err(error) => error,
+        };
+        assert_eq!(error.to_string(), "HTTP error: 404 Not Found");
+        assert_eq!(requests, 1, "HTTP status must not trigger a retry");
+    }
+
+    #[tokio::test]
+    async fn test_audio_download_error_does_not_expose_signed_url() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind local server");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+        let signature = "review-secret";
+        let url = format!("http://{addr}/prompt.wav?signature={signature}");
+
+        let result = FileAudioSource::download_bytes_with_timeout(
+            &url,
+            std::time::Duration::from_millis(50),
+        )
+        .await;
+        let error = result.expect_err("closed endpoint should fail both attempts");
+        let message = error.to_string();
+
+        assert!(
+            !message.contains(signature),
+            "error exposed signed URL: {message}"
+        );
+        assert!(!message.contains(&url), "error exposed full URL: {message}");
+    }
+
+    #[tokio::test]
+    async fn test_audio_download_retries_after_attempt_timeout() {
+        let pcm = sine_pcm(800, 8000, 440.0, 16_000.0);
+        let wav = build_wav(0x0001, 8000, 1, 16, &pcm_bytes(&pcm));
+        let (base, server) = serve_silent_then_fresh(wav.clone());
+        let url = format!("{base}/prompt.wav");
+
+        FileAudioSource::new(url.clone(), false)
+            .await
+            .expect("seed pooled connection");
+        let bytes = FileAudioSource::download_bytes_with_timeout(
+            &url,
+            std::time::Duration::from_millis(50),
+        )
+        .await
+        .expect("attempt timeout should retry on fresh connection");
+        let used_fresh_connection = server.join().expect("join HTTP server");
+
+        assert!(used_fresh_connection, "retry must use a fresh connection");
+        assert_eq!(bytes, wav);
     }
 
     #[tokio::test]

--- a/src/call/app/ivr/executor.rs
+++ b/src/call/app/ivr/executor.rs
@@ -269,6 +269,34 @@ impl StepIvrApp {
         self.pending_trace.take()
     }
 
+    fn record_pending_session_end(&mut self, preserve_trigger_detail: bool) {
+        let Some(pending) = self.pending_take() else {
+            return;
+        };
+        let duration_ms = self
+            .pending_start_instant
+            .map(|start| start.elapsed().as_millis() as u64)
+            .unwrap_or(0);
+        let completed = IvrTraceEntry {
+            step_end_time: Some(chrono::Utc::now().to_rfc3339()),
+            duration_ms,
+            ..pending
+        };
+        let completion_trigger = crate::rwi::TriggerInfo {
+            r#type: "session_end".into(),
+            detail: if preserve_trigger_detail {
+                completed.trigger.detail.clone()
+            } else {
+                None
+            },
+        };
+        self.record_trace(completed.clone());
+        self.record_trace(IvrTraceEntry {
+            trigger: completion_trigger,
+            ..completed
+        });
+    }
+
     fn record_trace(&self, entry: IvrTraceEntry) {
         if let Some(t) = self.effective_trace() {
             let ent = entry.clone();
@@ -298,11 +326,8 @@ impl StepIvrApp {
                 end_reason: entry.end_reason,
                 end_detail: entry.end_detail,
             };
-            let gw = gw.clone();
-            crate::utils::spawn(async move {
-                let guard = gw.read();
-                guard.fan_out(&call_id, &ev);
-            });
+            let guard = gw.read();
+            guard.fan_out(&call_id, &ev);
         }
     }
 
@@ -614,6 +639,7 @@ impl StepIvrApp {
                                 end_reason: None,
                                 end_detail: None,
                             });
+                            self.record_pending_session_end(true);
                             self.current_node =
                                 Some(self.request_next(Some(provider_event)).await?);
                             return Box::pin(self.__exec_node(ctrl, ctx)).await;
@@ -1630,6 +1656,7 @@ impl CallApp for StepIvrApp {
                 }
             }
             AppEvent::TransferResult { outcome } => {
+                self.record_pending_session_end(false);
                 self.current_node = Some(
                     self.request_next(Some(ProviderEvent::TransferResult { outcome }))
                         .await?,
@@ -1796,7 +1823,8 @@ impl CallApp for StepIvrApp {
         // RemoteHangup/Cancelled (caller hung up or system terminated the
         // session) — so the last executed node is captured and surfaced as an
         // `ivr_step_trace` event even when the session ends mid-flow.
-        let (last_action_type, last_step_id, last_step_name) = match &self.current_node {
+        let (last_action_type, last_step_id, last_step_name, last_extra) = match &self.current_node
+        {
             Some(node) => (
                 Self::action_type_label(&node.action).to_string(),
                 node.step_id
@@ -1805,11 +1833,13 @@ impl CallApp for StepIvrApp {
                 node.step_name
                     .clone()
                     .or_else(|| self.current_step_name.clone()),
+                node.extra.clone(),
             ),
             None => (
                 "session_end".to_string(),
                 self.current_step_id.clone(),
                 self.current_step_name.clone(),
+                None,
             ),
         };
         let caller = self
@@ -1839,7 +1869,7 @@ impl CallApp for StepIvrApp {
             step_start_time: None,
             step_end_time: Some(chrono::Utc::now().to_rfc3339()),
             duration_ms: 0,
-            extra: None,
+            extra: last_extra,
             end_reason: Some(end_sr.reason.clone()),
             end_detail: end_sr.detail.clone(),
         });
@@ -2096,6 +2126,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transfer_result_emits_session_end_before_next_node() {
+        use crate::call::app::ControllerEvent;
+        use crate::call::domain::TransferOutcome;
+        use crate::rwi::gateway::RwiGateway;
+
+        let mut transfer = ActionNode::new(EntryAction::Transfer {
+            target: "2001".into(),
+            params: HashMap::new(),
+            return_app: None,
+            return_target: None,
+        });
+        transfer.wait_for_result = true;
+        transfer.step_id = Some("transfer-step".into());
+        transfer.extra = Some(serde_json::json!({"nodetype": "transfer"}));
+        let hangup = ActionNode::new(EntryAction::Hangup {
+            prompt: None,
+            prompt_text: None,
+            prompt_voice: None,
+        });
+        let gateway = RwiGateway::new();
+        let mut events = gateway.subscribe_events();
+        let mut app = mock_app(vec![transfer, hangup]);
+        app.rwi_gateway = Some(Arc::new(parking_lot::RwLock::new(gateway)));
+
+        let mut stack = MockCallStack::run(Box::new(app), "1001", "2000");
+        stack
+            .assert_cmd(200, "accept", |c| matches!(c, CallCommand::Answer { .. }))
+            .await;
+        stack
+            .assert_cmd(200, "transfer", |c| {
+                matches!(c, CallCommand::TransferAwaitResult { target, .. } if target == "2001")
+            })
+            .await;
+        stack
+            .event_sender()
+            .send(ControllerEvent::TransferResult(TransferOutcome::NotConnected))
+            .unwrap();
+        stack
+            .assert_cmd(200, "hangup", |c| matches!(c, CallCommand::Hangup { .. }))
+            .await;
+
+        let ordinary = events.try_recv().expect("transfer trace must be enqueued");
+        let completed = events
+            .try_recv()
+            .expect("transfer completion trace must be enqueued");
+        assert_eq!(ordinary.event.payload["step_id"], "transfer-step");
+        assert_eq!(ordinary.event.payload["trigger"]["type"], "session_start");
+        assert_eq!(completed.event.payload["step_id"], "transfer-step");
+        assert_eq!(completed.event.payload["trigger"]["type"], "session_end");
+        assert!(completed.event.payload["trigger"]["detail"].is_null());
+    }
+
+    #[tokio::test]
     async fn test_prompt_then_transfer_via_next() {
         let node = ActionNode::with_next(
             EntryAction::Prompt {
@@ -2142,7 +2225,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_prompt_then_provider() {
-        let prompt = ActionNode::new(EntryAction::Prompt {
+        use crate::rwi::gateway::RwiGateway;
+
+        let mut prompt = ActionNode::new(EntryAction::Prompt {
             file: Some("hello.wav".into()),
             tts_text: None,
             tts_voice: None,
@@ -2150,15 +2235,20 @@ mod tests {
             interruptible: false,
             tts_api_url: None,
         });
-        let transfer = ActionNode::new(EntryAction::Transfer {
+        prompt.step_id = Some("prompt-step".into());
+        let mut transfer = ActionNode::new(EntryAction::Transfer {
             target: "2001".into(),
             params: HashMap::new(),
             return_app: None,
             return_target: None,
         });
+        transfer.step_id = Some("transfer-step".into());
+        let gateway = RwiGateway::new();
+        let mut events = gateway.subscribe_events();
+        let mut app = mock_app(vec![prompt, transfer]);
+        app.rwi_gateway = Some(Arc::new(parking_lot::RwLock::new(gateway)));
 
-        let mut stack =
-            MockCallStack::run(Box::new(mock_app(vec![prompt, transfer])), "1001", "2000");
+        let mut stack = MockCallStack::run(Box::new(app), "1001", "2000");
         stack
             .assert_cmd(200, "accept", |c| matches!(c, CallCommand::Answer { .. }))
             .await;
@@ -2181,6 +2271,15 @@ mod tests {
                 |c| matches!(c, CallCommand::Transfer { target, .. } if target == "2001"),
             )
             .await;
+
+        let prompt_trace = events.try_recv().expect("prompt trace must be enqueued");
+        let transfer_trace = events.try_recv().expect("transfer trace must be enqueued");
+        assert_eq!(prompt_trace.event.payload["step_id"], "prompt-step");
+        assert_eq!(
+            prompt_trace.event.payload["trigger"]["type"],
+            "session_start"
+        );
+        assert_eq!(transfer_trace.event.payload["step_id"], "transfer-step");
     }
 
     #[tokio::test]
@@ -4500,12 +4599,15 @@ mod tests {
         let mut app = StepIvrApp::with_provider(Box::new(MockProviderHandle(provider.clone())));
         app.trace = Some(trace.clone());
         app.ivr_name = Some("test-ivr".to_string());
-        app.current_node = Some(ActionNode::new(EntryAction::Transfer {
+        let mut current_node = ActionNode::new(EntryAction::Transfer {
             target: "2001".into(),
             params: HashMap::new(),
             return_app: None,
             return_target: None,
-        }));
+        });
+        current_node.extra = Some(serde_json::json!({"nodetype": "transfer"}));
+        app.current_node = Some(current_node);
+        app.extra = Some(serde_json::json!({"nodetype": "previous-node"}));
         app.current_step_id = Some("step-7".to_string());
         app.sess
             .variables
@@ -4532,6 +4634,11 @@ mod tests {
             "session_end trace must carry the last node action type"
         );
         assert_eq!(
+            session_end.extra,
+            Some(serde_json::json!({"nodetype": "transfer"})),
+            "session_end trace must preserve the last node metadata"
+        );
+        assert_eq!(
             session_end.end_reason,
             Some(crate::call::app::ivr::provider::SessionEndTag::UserHangup),
             "session_end trace must carry the end reason"
@@ -4540,6 +4647,55 @@ mod tests {
             !*provider.end_called.lock().unwrap(),
             "remote hangup must skip provider session end"
         );
+    }
+
+    #[tokio::test]
+    async fn test_step_trace_events_are_enqueued_in_record_order() {
+        use crate::rwi::gateway::RwiGateway;
+
+        let mut app = mock_app(vec![]);
+        app.sess
+            .variables
+            .insert("session_id".into(), "test-session".into());
+        let gateway = RwiGateway::new();
+        let mut events = gateway.subscribe_events();
+        app.rwi_gateway = Some(Arc::new(parking_lot::RwLock::new(gateway)));
+
+        let entry = |step_id: &str, trigger: crate::rwi::TriggerInfo| IvrTraceEntry {
+            session_id: "test-session".into(),
+            caller: "1001".into(),
+            callee: "2000".into(),
+            step_index: 1,
+            trigger,
+            provider_url: None,
+            action_type: "Prompt".into(),
+            action_json: None,
+            duration_ms: 0,
+            error: None,
+            step_id: Some(step_id.into()),
+            step_name: None,
+            step_start_time: None,
+            step_end_time: None,
+            extra: None,
+            end_reason: None,
+            end_detail: None,
+        };
+
+        app.record_trace(entry(
+            "step-normal",
+            crate::rwi::TriggerInfo::new("audio_complete"),
+        ));
+        app.record_trace(entry(
+            "step-end",
+            crate::rwi::TriggerInfo::new("session_end"),
+        ));
+
+        let first = events.try_recv().expect("ordinary trace must be enqueued");
+        let second = events
+            .try_recv()
+            .expect("session end trace must be enqueued");
+        assert_eq!(first.event.payload["step_id"], "step-normal");
+        assert_eq!(second.event.payload["step_id"], "step-end");
     }
 
     #[tokio::test]
@@ -4828,8 +4984,10 @@ mod tests {
     // ── Bug 7: InputPhone forwards collected digits to provider ───────────
 
     #[tokio::test]
-    async fn test_input_phone_forwards_to_provider() {
-        let input_phone = ActionNode::new(EntryAction::InputPhone {
+    async fn input_phone_emits_completion_before_followup() {
+        use crate::rwi::gateway::RwiGateway;
+
+        let mut input_phone = ActionNode::new(EntryAction::InputPhone {
             prompt: Some("enter_phone.wav".into()),
             prompt_text: None,
             prompt_voice: None,
@@ -4839,18 +4997,19 @@ mod tests {
             inter_digit_timeout_ms: 3_000,
             terminator: "#".into(),
         });
+        input_phone.step_id = Some("input-phone-step".into());
         let followup = ActionNode::new(EntryAction::Transfer {
             target: "2001".into(),
             params: HashMap::new(),
             return_app: None,
             return_target: None,
         });
+        let gateway = RwiGateway::new();
+        let mut events = gateway.subscribe_events();
+        let mut app = mock_app(vec![input_phone, followup]);
+        app.rwi_gateway = Some(Arc::new(parking_lot::RwLock::new(gateway)));
 
-        let mut stack = MockCallStack::run(
-            Box::new(mock_app(vec![input_phone, followup])),
-            "1001",
-            "2000",
-        );
+        let mut stack = MockCallStack::run(Box::new(app), "1001", "2000");
         stack
             .assert_cmd(200, "accept", |c| matches!(c, CallCommand::Answer { .. }))
             .await;
@@ -4878,6 +5037,19 @@ mod tests {
                 |c| matches!(c, CallCommand::Transfer { target, .. } if target == "2001"),
             )
             .await;
+
+        let ordinary = events.try_recv().expect("input phone trace must be enqueued");
+        let completed = events
+            .try_recv()
+            .expect("input phone completion trace must be enqueued");
+        assert_eq!(ordinary.event.payload["step_id"], "input-phone-step");
+        assert_eq!(ordinary.event.payload["trigger"]["type"], "phone_collected");
+        assert_eq!(completed.event.payload["step_id"], "input-phone-step");
+        assert_eq!(completed.event.payload["trigger"]["type"], "session_end");
+        assert_eq!(
+            completed.event.payload["trigger"]["detail"]["number"],
+            "12345678901"
+        );
     }
 
     #[tokio::test]

--- a/src/proxy/locator.rs
+++ b/src/proxy/locator.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 use rsipstack::{
+    sip::uri::ParamsExt,
     transaction::endpoint::{TargetLocator, TransportEventInspector},
     transport::{SipAddr, TransportEvent},
 };
@@ -321,6 +322,57 @@ impl DialogTargetLocator {
             .iter()
             .any(|addr| addr.addr.to_string() == home_proxy.addr.to_string())
     }
+
+    fn is_exact_contact(location: &Location, uri: &rsipstack::sip::Uri) -> bool {
+        location.aor == *uri
+    }
+
+    fn effective_port(uri: &rsipstack::sip::Uri) -> u16 {
+        uri.host_with_port
+            .port
+            .unwrap_or_else(|| {
+                uri.transport()
+                    .copied()
+                    .unwrap_or(if uri.scheme == Some(rsipstack::sip::Scheme::Sips) {
+                        rsipstack::sip::Transport::Tls
+                    } else {
+                        rsipstack::sip::Transport::Udp
+                    })
+                    .default_port()
+            })
+            .0
+    }
+
+    fn is_registered_aor(location: &Location, uri: &rsipstack::sip::Uri) -> bool {
+        let Some(registered_aor) = location.registered_aor.as_ref() else {
+            return false;
+        };
+        registered_aor.scheme == uri.scheme
+            && registered_aor.user() == uri.user()
+            && registered_aor
+                .host()
+                .to_string()
+                .eq_ignore_ascii_case(&uri.host().to_string())
+            && Self::effective_port(registered_aor) == Self::effective_port(uri)
+    }
+
+    fn is_gruu(location: &Location, uri: &rsipstack::sip::Uri) -> bool {
+        let Some(gruu) = location.gruu.as_ref() else {
+            return false;
+        };
+        let uri = uri.to_string();
+        gruu == &uri || gruu.eq_ignore_ascii_case(&uri)
+    }
+
+    fn is_home_proxy_target(location: &Location, uri: &rsipstack::sip::Uri) -> bool {
+        let Some(home_proxy) = location.home_proxy.as_ref() else {
+            return false;
+        };
+        let Some(registered_aor) = location.registered_aor.as_ref() else {
+            return false;
+        };
+        registered_aor.user() == uri.user() && home_proxy.addr == uri.host_with_port
+    }
 }
 
 #[async_trait]
@@ -330,6 +382,34 @@ impl TargetLocator for DialogTargetLocator {
         if let Ok(locs) = &locs
             && !locs.is_empty()
         {
+            let has_exact_contact = locs
+                .iter()
+                .any(|location| Self::is_exact_contact(location, uri));
+            let has_registered_aor = !has_exact_contact
+                && locs
+                    .iter()
+                    .any(|location| Self::is_registered_aor(location, uri));
+            let has_gruu = !has_exact_contact
+                && !has_registered_aor
+                && locs.iter().any(|location| Self::is_gruu(location, uri));
+            let is_invalid_contact = is_webrtc_invalid_host(&uri.host().to_string());
+            let locs: Vec<_> = locs
+                .iter()
+                .filter(|location| {
+                    if has_exact_contact {
+                        Self::is_exact_contact(location, uri)
+                    } else if has_registered_aor {
+                        Self::is_registered_aor(location, uri)
+                    } else if has_gruu {
+                        Self::is_gruu(location, uri)
+                    } else if is_invalid_contact {
+                        true
+                    } else {
+                        Self::is_home_proxy_target(location, uri)
+                    }
+                })
+                .collect();
+
             if let Some(loc) = locs.iter().find(|loc| {
                 if !self.cluster_enabled {
                     return false;
@@ -1250,8 +1330,10 @@ mod tests {
     #[tokio::test]
     async fn dialog_target_locator_routes_registered_aor_via_home_proxy() {
         let locator = MemoryLocator::new();
-        let registered_aor: rsipstack::sip::Uri = "sip:alice@10.0.0.1".try_into().unwrap();
-        let target_uri: rsipstack::sip::Uri = "sip:alice@10.0.0.1:5060".try_into().unwrap();
+        let registered_aor: rsipstack::sip::Uri =
+            "sip:line@example.com;transport=ws".try_into().unwrap();
+        let target_uri: rsipstack::sip::Uri =
+            "sip:line@example.com:80;transport=ws".try_into().unwrap();
 
         let destination = SipAddr {
             r#type: Some(Transport::Udp),
@@ -1265,10 +1347,12 @@ mod tests {
 
         locator
             .register(
-                "alice",
-                Some("10.0.0.1"),
+                "line",
+                Some("example.com"),
                 Location {
-                    aor: registered_aor.clone(),
+                    aor: "sip:browser@random.invalid;transport=ws"
+                        .try_into()
+                        .unwrap(),
                     expires: 3600,
                     destination: Some(destination.clone()),
                     home_proxy: Some(home_proxy.clone()),
@@ -1286,6 +1370,45 @@ mod tests {
             result, home_proxy,
             "DialogTargetLocator should route registered AOR via home_proxy"
         );
+    }
+
+    #[tokio::test]
+    async fn dialog_target_locator_routes_gruu_to_registered_destination() {
+        let locator = MemoryLocator::new();
+        let gruu_uri: rsipstack::sip::Uri = format!("sip:gruu-user{}{}", "@", "example.test")
+            .try_into()
+            .unwrap();
+        let destination = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: HostWithPort::try_from("192.168.1.20:5060").unwrap(),
+        };
+
+        locator
+            .register(
+                "gruu-user",
+                Some("example.test"),
+                Location {
+                    aor: format!("sip:contact{}{}", "@", "device.test")
+                        .try_into()
+                        .unwrap(),
+                    registered_aor: Some(
+                        format!("sip:gruu-user{}{}", "@", "canonical.test")
+                            .try_into()
+                            .unwrap(),
+                    ),
+                    destination: Some(destination.clone()),
+                    gruu: Some(gruu_uri.to_string()),
+                    expires: 3600,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![], false);
+        let result = target_locator.locate(&gruu_uri).await.unwrap();
+
+        assert_eq!(result, destination);
     }
 
     #[tokio::test]
@@ -1532,6 +1655,99 @@ mod tests {
         assert_eq!(
             result, destination,
             "DialogTargetLocator should keep contact destination when URI is not registered AOR"
+        );
+    }
+
+    #[tokio::test]
+    async fn dialog_target_locator_does_not_replace_an_unregistered_explicit_contact() {
+        let locator = MemoryLocator::new();
+        let registered_contact: rsipstack::sip::Uri =
+            "sip:caller@192.168.2.3:62106".try_into().unwrap();
+        let dialog_contact: rsipstack::sip::Uri = "sip:caller@127.0.0.1:5061".try_into().unwrap();
+
+        let registered_destination = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: HostWithPort::try_from("192.168.2.3:62106").unwrap(),
+        };
+
+        locator
+            .register(
+                "caller",
+                Some("localhost"),
+                Location {
+                    aor: registered_contact,
+                    registered_aor: Some("sip:caller@localhost".try_into().unwrap()),
+                    expires: 3600,
+                    destination: Some(registered_destination),
+                    last_modified: Some(Instant::now()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![], false);
+        let result = target_locator.locate(&dialog_contact).await.unwrap();
+
+        assert_eq!(
+            result,
+            SipAddr::try_from(&dialog_contact).unwrap(),
+            "an explicit Contact must not be replaced by another registration for the same user"
+        );
+    }
+
+    #[tokio::test]
+    async fn dialog_target_locator_does_not_fold_contact_user_case() {
+        let locator = MemoryLocator::new();
+        let exact_contact: rsipstack::sip::Uri = "sip:Line@192.168.1.10:5060;transport=tcp"
+            .try_into()
+            .unwrap();
+        let other_contact: rsipstack::sip::Uri = "sip:line@192.168.1.10:5060;transport=tcp"
+            .try_into()
+            .unwrap();
+        let exact_destination = SipAddr {
+            r#type: Some(Transport::Tcp),
+            addr: HostWithPort::try_from("192.168.1.11:5060").unwrap(),
+        };
+
+        locator
+            .register(
+                "line",
+                Some("localhost"),
+                Location {
+                    aor: exact_contact.clone(),
+                    expires: 3600,
+                    destination: Some(exact_destination.clone()),
+                    last_modified: Some(Instant::now() - Duration::from_secs(1)),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        locator
+            .register(
+                "line",
+                Some("localhost"),
+                Location {
+                    aor: other_contact,
+                    expires: 3600,
+                    destination: Some(SipAddr {
+                        r#type: Some(Transport::Tcp),
+                        addr: HostWithPort::try_from("192.168.1.12:5060").unwrap(),
+                    }),
+                    last_modified: Some(Instant::now()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let target_locator = DialogTargetLocator::new(Arc::new(Box::new(locator)), vec![], false);
+        let result = target_locator.locate(&exact_contact).await.unwrap();
+
+        assert_eq!(
+            result, exact_destination,
+            "SIP Contact users are case-sensitive and must not be folded"
         );
     }
 


### PR DESCRIPTION
## Problem

This PR addresses three reliability issues:

- IVR trace events could be reordered because each event was dispatched in a separate asynchronous task. Transfer and phone-input nodes could also advance without
  emitting their completion marker, while remote hangups could lose the last node’s metadata.

- Dialog routing could select an unrelated registration for the same user and replace an explicit in-dialog Contact.
- Audio downloads failed immediately on stale pooled connections. The previous timeout was also too long for call processing, and errors could expose signed URL
  parameters.

## Changes

- Preserve trace enqueue order without serializing downstream event processing.
- Emit the existing session_end completion event for transfer and phone-input nodes before moving to the next node. Phone-input details and remote-hangup metadata
  are retained.

- Select dialog targets by intent: exact Contact, registered AoR, GRUU, WebRTC .invalid Contact, then home proxy. Existing cluster routing and direct URI fallback
  remain unchanged.

- Limit each audio download attempt to 2 seconds.
- Retry transport, body-read, and timeout failures once with a fresh client.
- Do not retry HTTP status errors, and redact URLs from download errors.

## Compatibility

- Keeps the existing session_end trace contract; no new step_complete event is introduced.
- Does not change public APIs or serialize the full call-processing path.
- Explicit SIP targets and existing cluster behavior are preserved.

## Verification

- 41 audio-source tests passed, including stale connections, partial bodies, timeouts, non-retryable HTTP errors, and URL redaction.
- 10 dialog-target locator tests passed, covering Contacts, AoRs, GRUUs, home proxies, and case-sensitive SIP users.
- 4 IVR trace contract tests passed, covering ordering, transfer completion, phone-input completion, and remote hangup metadata.
- Release-profile Cargo check with commerce,contact-center passed.
