### PR TITLE
fix: advertise concrete SIP contacts and use owner-local agent presence

### DIFF
--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1698,8 +1698,22 @@ impl SipServerInner {
                 .or(port)
         };
 
-        // Inbound: without a reliable destination hint, prefer bind address (LAN-safe).
-        self.contact_uri_for_transport(transport, port_override, None)
+        // A wildcard is only a listener instruction; generate the Contact from this flow's local IP.
+        let contact = self.sip_contact_config.load();
+        let rtp = self.rtp_config.load();
+        let sip_addr = super::sip_contact::build_transaction_contact_sip_addr(
+            &proxy,
+            &contact,
+            rtp.external_ip.as_deref(),
+            transport,
+            port_override,
+            conn_addr,
+        )?;
+        Some(build_contact_uri(
+            &self.contact_username,
+            &sip_addr,
+            Some(transport),
+        ))
     }
 
     /// Contact URI for an outbound leg toward `target`.

--- a/src/proxy/sip_contact.rs
+++ b/src/proxy/sip_contact.rs
@@ -100,8 +100,54 @@ pub fn build_contact_sip_addr(
     port_override: Option<u16>,
     destination: Option<IpAddr>,
 ) -> Option<SipAddr> {
+    build_contact_sip_addr_with_bind_ip(
+        proxy,
+        contact,
+        rtp_external_ip,
+        transport,
+        port_override,
+        destination,
+        &proxy.addr,
+    )
+}
+
+pub fn build_transaction_contact_sip_addr(
+    proxy: &ProxyConfig,
+    contact: &SipContactConfig,
+    rtp_external_ip: Option<&str>,
+    transport: Transport,
+    port_override: Option<u16>,
+    connection: &SipAddr,
+) -> Option<SipAddr> {
+    // Wildcard binds cannot be advertised; the accepted flow carries the concrete local host.
+    let actual_bind_ip = proxy
+        .addr
+        .parse::<IpAddr>()
+        .ok()
+        .filter(IpAddr::is_unspecified)
+        .map(|_| connection.addr.host.to_string());
+    build_contact_sip_addr_with_bind_ip(
+        proxy,
+        contact,
+        rtp_external_ip,
+        transport,
+        port_override,
+        None,
+        actual_bind_ip.as_deref().unwrap_or(&proxy.addr),
+    )
+}
+
+fn build_contact_sip_addr_with_bind_ip(
+    proxy: &ProxyConfig,
+    contact: &SipContactConfig,
+    rtp_external_ip: Option<&str>,
+    transport: Transport,
+    port_override: Option<u16>,
+    destination: Option<IpAddr>,
+    bind_ip: &str,
+) -> Option<SipAddr> {
     let listener = listener_sip_addr(proxy, transport, port_override)?;
-    let host = resolve_contact_host(contact, &proxy.addr, rtp_external_ip, destination);
+    let host = resolve_contact_host(contact, bind_ip, rtp_external_ip, destination);
     Some(replace_contact_host(&listener, &host))
 }
 
@@ -248,5 +294,61 @@ mod tests {
         )
         .unwrap();
         assert_eq!(addr.addr.to_string(), "203.0.113.10:5061");
+    }
+
+    #[test]
+    fn build_contact_sip_addr_uses_actual_bind_ip_for_wildcard_listener() {
+        let proxy = ProxyConfig {
+            addr: "0.0.0.0".to_string(),
+            udp_port: Some(8060),
+            ..ProxyConfig::default()
+        };
+        let contact = SipContactConfig {
+            local_networks: default_local_networks(),
+            contact_lan_use_bind: true,
+            ..Default::default()
+        };
+
+        let connection = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: HostWithPort::try_from("192.0.2.10:8060").unwrap(),
+        };
+        let addr = build_transaction_contact_sip_addr(
+            &proxy,
+            &contact,
+            None,
+            Transport::Udp,
+            None,
+            &connection,
+        )
+        .unwrap();
+
+        assert_eq!(addr.addr.to_string(), "192.0.2.10:8060");
+    }
+
+    #[test]
+    fn build_transaction_contact_sip_addr_preserves_explicit_bind_ip() {
+        let proxy = ProxyConfig {
+            addr: "192.0.2.20".to_string(),
+            udp_port: Some(8060),
+            ..ProxyConfig::default()
+        };
+        let contact = SipContactConfig::default();
+        let connection = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: HostWithPort::try_from("192.0.2.10:8060").unwrap(),
+        };
+
+        let addr = build_transaction_contact_sip_addr(
+            &proxy,
+            &contact,
+            None,
+            Transport::Udp,
+            None,
+            &connection,
+        )
+        .unwrap();
+
+        assert_eq!(addr.addr.to_string(), "192.0.2.20:8060");
     }
 }


### PR DESCRIPTION
## Summary

- Advertise the accepted connection's local address in SIP Contact headers when the listener uses a wildcard
bind.
- Preserve configured public Contact selection and explicit bind addresses.
- Return live agent presence from the owning instance while retaining shared presence for remotely owned
agents.

## Problem

Wildcard addresses such as `0.0.0.0` are valid listener instructions but are not usable Contact addresses.
Inbound SIP transactions could therefore advertise an unreachable Contact.

Agent presence snapshots are propagated asynchronously. On the instance that owns an agent, the shared
snapshot can lag behind the live registry and expose stale status or call counts.

## Solution

Resolve inbound transaction Contacts from the accepted flow's concrete local address only when the listener
bind is unspecified. Existing explicit bind and public address selection remain unchanged.

For agent reads, use the live registry when the shared presence record identifies the current instance as the
owner. Continue using the shared snapshot for agents owned by remote instances.

## Test coverage

- Covers wildcard listener and explicit bind Contact selection.
- Covers both locally owned and remotely owned agent presence reads.
