### PR TITLE
fix: preserve agent presence ownership and prevent duplicate IVR DTMF

### DIFF
--- a/src/call/app/ivr/config.rs
+++ b/src/call/app/ivr/config.rs
@@ -448,6 +448,9 @@ impl EntryAction {
 pub struct ActionNode {
     #[serde(flatten)]
     pub action: EntryAction,
+    /// Ignore caller digits while this non-interruptible prompt is playing.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub ignore_prompt_dtmf: bool,
     #[serde(default, skip_serializing_if = "is_false")]
     pub wait_for_result: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -464,6 +467,7 @@ impl ActionNode {
     pub fn new(action: EntryAction) -> Self {
         Self {
             action,
+            ignore_prompt_dtmf: false,
             wait_for_result: false,
             next: None,
             step_id: None,
@@ -475,6 +479,7 @@ impl ActionNode {
     pub fn with_next(action: EntryAction, next: ActionNode) -> Self {
         Self {
             action,
+            ignore_prompt_dtmf: false,
             wait_for_result: false,
             next: Some(Box::new(next)),
             step_id: None,

--- a/src/call/app/ivr/executor.rs
+++ b/src/call/app/ivr/executor.rs
@@ -33,6 +33,8 @@ pub struct StepIvrApp {
     pending_menu: Option<PendingMenu>,
     current_track_id: Option<String>,
     interrupt_on_dtmf: bool,
+    /// Whether digits must be ignored while the current non-interruptible prompt is playing.
+    ignore_prompt_dtmf: bool,
     /// Whether the IVR is currently expecting DTMF input.
     ///
     /// Set to `true` once a `DtmfMenu` greeting finishes playing (or when the
@@ -126,6 +128,7 @@ impl StepIvrApp {
             pending_menu: None,
             current_track_id: None,
             interrupt_on_dtmf: false,
+            ignore_prompt_dtmf: false,
             awaiting_dtmf: false,
             tts_service: None,
             trace: None,
@@ -167,6 +170,7 @@ impl StepIvrApp {
             pending_menu: None,
             current_track_id: None,
             interrupt_on_dtmf: false,
+            ignore_prompt_dtmf: false,
             awaiting_dtmf: false,
             tts_service: None,
             trace: None,
@@ -1287,6 +1291,8 @@ impl StepIvrApp {
                 self.pending_menu = Some(self.build_pending_menu(&node.action));
             } else if node.action.is_interruptible() {
                 self.interrupt_on_dtmf = true;
+            } else if matches!(node.action, EntryAction::Prompt { .. }) {
+                self.ignore_prompt_dtmf = node.ignore_prompt_dtmf;
             }
         }
         if matches!(&result, ActionResult::WaitFor(WaitEvent::NoAudio)) {
@@ -1539,6 +1545,13 @@ impl CallApp for StepIvrApp {
         ctrl: &mut CallController,
         context: &ApplicationContext,
     ) -> anyhow::Result<AppAction> {
+        // A provider may opt into legacy announcement semantics: finish the
+        // prompt but ignore digits handled while that prompt is active.
+        if self.ignore_prompt_dtmf {
+            tracing::info!("StepIvrApp: ignoring DTMF during non-interruptible prompt");
+            return Ok(AppAction::Continue);
+        }
+
         // DTMF received — clear any stale timeout flag so a later hangup is
         // not misclassified as timeout-induced.
         self.timeout_induced = false;
@@ -1682,6 +1695,7 @@ impl CallApp for StepIvrApp {
         let was_menu = self.pending_menu.is_some();
         self.current_track_id = None;
         self.interrupt_on_dtmf = false;
+        self.ignore_prompt_dtmf = false;
 
         if was_menu && track_id == "ivr_menu_greeting" {
             if let Some(ref menu) = self.pending_menu {
@@ -6238,7 +6252,7 @@ mod tests {
         if let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) {
             let event_type = value["event"]["type"].as_str().unwrap_or("");
             if event_type == "session_start" {
-                return br#"{"type":"prompt","tts_text":"IVR step, press 1 or 2.","interruptible":true}"#
+                return br#"{"type":"prompt","tts_text":"IVR step announcement.","interruptible":false,"ignore_prompt_dtmf":true}"#
                     .to_vec();
             }
             if event_type == "dtmf" && value["event"]["digit"].as_str() == Some("2") {
@@ -6295,9 +6309,10 @@ mod tests {
         };
         let prompt = step_provider.next_action(ctx).await.unwrap();
         assert!(
-            matches!(prompt.action, EntryAction::Prompt { ref tts_text, interruptible: true, .. }
+            matches!(prompt.action, EntryAction::Prompt { ref tts_text, interruptible: false, .. }
                 if tts_text.as_deref().is_some_and(|text| text.contains("IVR step")))
         );
+        assert!(prompt.ignore_prompt_dtmf);
 
         let ctx = ProviderContext {
             event: Some(ProviderEvent::Dtmf {
@@ -6375,11 +6390,7 @@ mod tests {
 
     // ── DTMF delivery in step-provider mode ──────────────────────────────
     //
-    // Regression: a digit pressed while the current step is a non-interruptible
-    // prompt (or the provider response is in flight) used to be silently
-    // dropped by `on_dtmf` ("ignoring early DTMF"), so "press 2 → transfer"
-    // never reached the provider. It must now be buffered and delivered on the
-    // next step.
+    // DTMF delivery must preserve the current prompt's interruption contract.
 
     fn event_label(ev: &Option<ProviderEvent>) -> String {
         match ev {
@@ -6397,6 +6408,7 @@ mod tests {
     /// announcement; dtmf "2" → transfer to 2001; anything else → hangup.
     struct ScriptedProvider {
         log: Arc<std::sync::Mutex<Vec<String>>>,
+        ignore_prompt_dtmf: bool,
     }
 
     #[async_trait]
@@ -6413,14 +6425,16 @@ mod tests {
                     tts_api_url: None,
                 })),
                 Some(ProviderEvent::AudioComplete { .. }) => {
-                    Ok(ActionNode::new(EntryAction::Prompt {
+                    let mut node = ActionNode::new(EntryAction::Prompt {
                         file: Some("announce.wav".into()),
                         tts_text: None,
                         tts_voice: None,
                         record_name_list: None,
                         interruptible: false,
                         tts_api_url: None,
-                    }))
+                    });
+                    node.ignore_prompt_dtmf = self.ignore_prompt_dtmf;
+                    Ok(node)
                 }
                 Some(ProviderEvent::Dtmf { digit }) if digit == "2" => {
                     Ok(ActionNode::new(EntryAction::Transfer {
@@ -6461,9 +6475,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_step_provider_buffers_dtmf_during_non_interruptible_prompt() {
+    async fn test_step_provider_buffers_dtmf_by_default_during_non_interruptible_prompt() {
         let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let app = StepIvrApp::with_provider(Box::new(ScriptedProvider { log: log.clone() }));
+        let app = StepIvrApp::with_provider(Box::new(ScriptedProvider {
+            log: log.clone(),
+            ignore_prompt_dtmf: false,
+        }));
+        let mut stack = MockCallStack::run(Box::new(app), "1001", "2000");
+
+        stack
+            .assert_cmd(200, "accept", |c| matches!(c, CallCommand::Answer { .. }))
+            .await;
+        stack
+            .assert_cmd(500, "play-welcome", |c| play_file_cmd(c, "welcome.wav"))
+            .await;
+        stack.audio_complete("ivr_prompt");
+        stack
+            .assert_cmd(500, "play-announce", |c| play_file_cmd(c, "announce.wav"))
+            .await;
+
+        stack.dtmf("2");
+        stack.audio_complete("ivr_prompt");
+        stack
+            .assert_cmd(
+                500,
+                "transfer",
+                |c| matches!(c, CallCommand::Transfer { target, .. } if target == "2001"),
+            )
+            .await;
+
+        let log = log.lock().unwrap();
+        assert_eq!(
+            log.as_slice(),
+            ["session_start", "audio_complete", "dtmf:2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_step_provider_ignores_dtmf_during_non_interruptible_prompt() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let app = StepIvrApp::with_provider(Box::new(ScriptedProvider {
+            log: log.clone(),
+            ignore_prompt_dtmf: true,
+        }));
         let mut stack = MockCallStack::run(Box::new(app), "1001", "2000");
 
         stack
@@ -6479,33 +6533,33 @@ mod tests {
             .assert_cmd(500, "play-announce", |c| play_file_cmd(c, "announce.wav"))
             .await;
 
-        // Press 2 during the non-interruptible announcement — must be buffered,
-        // not dropped.
+        // Press 2 during the non-interruptible announcement. The announcement
+        // must finish naturally without forwarding the digit to the provider.
         stack.dtmf("2");
-        tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // Announcement completes → buffered digit is delivered to the provider
-        // (as a dtmf event) → provider returns transfer.
+        // Announcement completion remains an audio_complete event, so the
+        // provider returns its next announcement instead of the DTMF transfer.
         stack.audio_complete("ivr_prompt");
         stack
-            .assert_cmd(
-                500,
-                "transfer",
-                |c| matches!(c, CallCommand::Transfer { target, .. } if target == "2001"),
-            )
+            .assert_cmd(500, "play-next-announce", |c| {
+                play_file_cmd(c, "announce.wav")
+            })
             .await;
 
         let log = log.lock().unwrap();
-        assert!(
-            log.iter().any(|e| e == "dtmf:2"),
-            "provider never received the buffered dtmf:2 — got {log:?}"
+        assert_eq!(
+            log.as_slice(),
+            ["session_start", "audio_complete", "audio_complete"]
         );
     }
 
     #[tokio::test]
     async fn test_step_provider_barges_in_interruptible_prompt() {
         let log = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let app = StepIvrApp::with_provider(Box::new(ScriptedProvider { log: log.clone() }));
+        let app = StepIvrApp::with_provider(Box::new(ScriptedProvider {
+            log: log.clone(),
+            ignore_prompt_dtmf: false,
+        }));
         let mut stack = MockCallStack::run(Box::new(app), "1001", "2000");
 
         stack

--- a/src/call/app/ivr/provider.rs
+++ b/src/call/app/ivr/provider.rs
@@ -250,6 +250,7 @@ impl Default for RetryConfig {
                     prompt_text: None,
                     prompt_voice: None,
                 },
+                ignore_prompt_dtmf: false,
                 wait_for_result: false,
                 next: None,
                 step_id: None,

--- a/src/call/app/ivr/third_party.rs
+++ b/src/call/app/ivr/third_party.rs
@@ -281,6 +281,7 @@ impl ThirdPartyTreeProvider {
         });
         ActionNode {
             action,
+            ignore_prompt_dtmf: false,
             wait_for_result: false,
             next,
             step_id: None,

--- a/src/proxy/proxy_call/sip_session/session.rs
+++ b/src/proxy/proxy_call/sip_session/session.rs
@@ -1871,9 +1871,9 @@ impl SipSession {
         }
     }
 
-    /// Subscribe to the MediaBridge DTMF bus and forward RTP RFC 2833 digits
-    /// to the running app + RWI gateway + bridge WebSocket. Called once at
-    /// session construction when media is anchored.
+    /// Subscribe to the MediaBridge DTMF bus and route RTP RFC 2833 digits to
+    /// the active bridge, or otherwise to the running app and RWI gateway.
+    /// Called once at session construction when media is anchored.
     fn spawn_dtmf_forwarder(&self) {
         let Some(mb) = self.media.bridge.as_ref() else {
             return;

--- a/src/proxy/proxy_call/sip_session/tests/mod.rs
+++ b/src/proxy/proxy_call/sip_session/tests/mod.rs
@@ -63,18 +63,16 @@ fn forward_dtmf_skips_app_injection_when_no_app_is_running() {
     assert_eq!(runtime.inject_calls.load(Ordering::SeqCst), 0);
 }
 
-/// While a bridge is active (armed `bridge_dtmf_tx`), a digit must be
-/// 1. forwarded to the bridge WebSocket (pre-existing behaviour),
-/// 2. buffered for the return-app flow, and
-/// 3. reported as an `ivr_step_trace` carrying the originating node context
-///    and the digit (consumer contract for menu/TTS nodes).
+/// While a bridge is active (armed `bridge_dtmf_tx`), the bridge owns the
+/// digit. It must be forwarded, buffered for the return app, and traced, but
+/// never also injected into the suspended app as a second business input.
 #[test]
-fn forward_dtmf_with_active_bridge_emits_trace_and_buffers_digit() {
+fn forward_dtmf_with_active_bridge_owns_digit_without_app_injection() {
     use crate::proxy::proxy_call::sip_session::transfer::BridgeTraceContext;
     use crate::rwi::gateway::RwiGateway;
 
     let runtime = Arc::new(DtmfAppRuntime {
-        running: false,
+        running: true,
         inject_calls: AtomicUsize::new(0),
     });
     let app_runtime: Arc<dyn AppRuntime> = runtime.clone();
@@ -113,6 +111,7 @@ fn forward_dtmf_with_active_bridge_emits_trace_and_buffers_digit() {
     let v: serde_json::Value = serde_json::from_str(&ws_json).unwrap();
     assert_eq!(v["type"], "dtmf");
     assert_eq!(v["digit"], "1");
+    assert_eq!(runtime.inject_calls.load(Ordering::SeqCst), 0);
 
     // 2. buffered for the return-app flow
     assert_eq!(digits.lock().clone(), vec!["1".to_string()]);

--- a/src/proxy/proxy_call/sip_session/util.rs
+++ b/src/proxy/proxy_call/sip_session/util.rs
@@ -224,9 +224,8 @@ pub(super) fn inject_dtmf_into_app(
     }
 }
 
-/// Returns `true` when the digit was injected into a running app. The
-/// bridge websocket forward always fires immediately regardless of app
-/// state, so replaying a buffered digit later must use
+/// Returns `true` when the digit was accepted by the active bridge or injected
+/// into a running app. Replaying a buffered digit later must use
 /// [`inject_dtmf_into_app`] instead of calling this again.
 ///
 /// While a bridge is active (`bridge_dtmf_tx` armed) the digit is also
@@ -248,7 +247,6 @@ pub(super) fn forward_dtmf_event(
     callee: &str,
     sip_headers: Option<std::collections::HashMap<String, String>>,
 ) -> bool {
-    let injected = inject_dtmf_into_app(digit, leg_id, session_id, app_runtime, rwi_gateway);
     let digit_str = digit.to_string();
     if let Some(tx) = bridge_dtmf_tx.read().as_ref() {
         let _ = tx.send(
@@ -290,8 +288,11 @@ pub(super) fn forward_dtmf_event(
             };
             gw.read().fan_out(session_id, &ev);
         }
+        // The bridge owns media while active. Injecting the same digit into
+        // the suspended app would replay one physical key as a second input.
+        return true;
     }
-    injected
+    inject_dtmf_into_app(digit, leg_id, session_id, app_runtime, rwi_gateway)
 }
 
 pub(super) fn trunk_host_port(dest: &str) -> Option<(String, u16)> {

--- a/src/proxy/tests/test_sip_session_regressions.rs
+++ b/src/proxy/tests/test_sip_session_regressions.rs
@@ -20,7 +20,7 @@ use crate::proxy::routing::{
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Instant;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -143,6 +143,22 @@ struct StartOnlyRuntime {
     start_calls: AtomicUsize,
 }
 
+struct BridgeReturnRuntime {
+    running: AtomicBool,
+    inject_calls: AtomicUsize,
+    started_params: std::sync::Mutex<Vec<Option<serde_json::Value>>>,
+}
+
+impl BridgeReturnRuntime {
+    fn new() -> Self {
+        Self {
+            running: AtomicBool::new(true),
+            inject_calls: AtomicUsize::new(0),
+            started_params: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
 impl StartOnlyRuntime {
     fn new() -> Self {
         Self {
@@ -205,6 +221,40 @@ impl AppRuntime for StartOnlyRuntime {
 
     fn current_app(&self) -> Option<String> {
         None
+    }
+}
+
+#[async_trait]
+impl AppRuntime for BridgeReturnRuntime {
+    async fn start_app(
+        &self,
+        app_name: &str,
+        params: Option<serde_json::Value>,
+        _auto_answer: bool,
+    ) -> crate::call::runtime::AppResult<()> {
+        if self.running.swap(true, Ordering::SeqCst) {
+            return Err(AppRuntimeError::AlreadyRunning(app_name.to_string()));
+        }
+        self.started_params.lock().unwrap().push(params);
+        Ok(())
+    }
+
+    async fn stop_app(&self, _reason: Option<String>) -> crate::call::runtime::AppResult<()> {
+        self.running.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn inject_event(&self, _event: serde_json::Value) -> crate::call::runtime::AppResult<()> {
+        self.inject_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
+
+    fn current_app(&self) -> Option<String> {
+        self.is_running().then(|| "ivr".to_string())
     }
 }
 
@@ -532,6 +582,70 @@ async fn test_connected_dynamic_leg_failure_returns_to_ivr_when_set() {
         .map(|d| d.id())
         .expect("caller dialog present");
     assert!(!session.pending_hangup.contains(&caller_dialog_id));
+}
+
+#[tokio::test]
+async fn bridge_rtp_dtmf_reaches_return_app_once_without_stale_app_injection() {
+    use crate::media::leg::{LegConfig, LegInner};
+    use crate::media::media_bridge::LegSide;
+    use rustrtc::peer_connection::RtpObserver;
+
+    let dialplan = build_dialplan_with_mode(MediaProxyMode::Auto).with_application(
+        "ivr".to_string(),
+        None,
+        true,
+    );
+    let mut session = build_session(dialplan).await;
+    let runtime = Arc::new(BridgeReturnRuntime::new());
+    session.app_runtime = runtime.clone();
+
+    let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel();
+    *session.bridge_dtmf_tx.write() = Some(bridge_tx);
+    session.meta.transfer_return_app = Some(ReturnAppSpec {
+        app_name: "ivr".to_string(),
+        params: serde_json::json!({"file": "main-menu"}),
+    });
+
+    let caller_leg = LegInner::new("caller", &LegConfig::rtp_pcmu(), None).unwrap();
+    caller_leg.ingress_tap().set_dtmf_payload_types(vec![101]);
+    session
+        .media
+        .bridge
+        .as_mut()
+        .expect("anchored media bridge")
+        .replace_leg(LegSide::A, caller_leg.clone())
+        .await;
+
+    let packet = rustrtc::rtp::RtpPacket::new(
+        rustrtc::rtp::RtpHeader::new(101, 1, 160, 1234),
+        vec![6, 0x80, 0, 160],
+    );
+    caller_leg
+        .ingress_tap()
+        .on_ingress(&packet, "127.0.0.1:40000".parse().unwrap());
+
+    let bridge_event = tokio::time::timeout(std::time::Duration::from_secs(1), bridge_rx.recv())
+        .await
+        .expect("bridge DTMF timeout")
+        .expect("bridge DTMF channel closed");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&bridge_event).unwrap()["digit"],
+        "6"
+    );
+    assert_eq!(runtime.inject_calls.load(Ordering::SeqCst), 0);
+
+    // Bridge cleanup disarms forwarding before the stored return app resumes.
+    *session.bridge_dtmf_tx.write() = None;
+    session
+        .execute_command(CallCommand::StartReturnApp, None)
+        .await;
+
+    let started_params = runtime.started_params.lock().unwrap();
+    assert_eq!(started_params.len(), 1);
+    assert_eq!(
+        started_params[0].as_ref().unwrap()["ivr_params"]["bridge_dtmf_digits"],
+        "6"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR fixes state ownership issues in agent presence synchronization and IVR DTMF handling.

## Changes

- Update the CC addon to preserve agent presence ownership across process restarts.
  - Reject persisted snapshots written by the local instance.
  - Accept newer snapshots from the same remote owner.
  - Keep the owning instance when updating an existing in-memory agent.

- Add an opt-in `ignore_prompt_dtmf` policy for non-interruptible IVR prompts.
  - Preserve DTMF buffering as the default behavior.
  - Ignore digits only while an explicitly configured non-interruptible prompt is active.
  - Keep interruptible prompt behavior unchanged.

- Make an active media bridge the single owner of incoming DTMF.
  - Forward and buffer the digit for the bridge return flow.
  - Avoid injecting the same physical key into a stale app runtime.
  - Prevent one key press from being processed as multiple business inputs.

## Testing

- Updated agent presence lifecycle coverage for local and remote snapshot ownership.
- Covered default prompt buffering, opt-in DTMF ignoring, and interruptible prompt behavior.
- Added an RTP telephone-event regression covering bridge forwarding and return-app replay, verifying that one physical digit is consumed only once.
