### PR TITLE
perf: reuse a shared keepalive HTTP client instead of building one per call session

### DIFF
--- a/src/call/app/agent_registry/http.rs
+++ b/src/call/app/agent_registry/http.rs
@@ -35,8 +35,7 @@ impl HttpRegistry {
         Self {
             base_url,
             api_key,
-            client: crate::http_util::build_keepalive_client(None, None)
-                .unwrap_or_else(|_| reqwest::Client::new()),
+            client: crate::http_util::shared_keepalive_client().clone(),
             cache: DashMap::new(),
             rr_counter: RwLock::new(0),
             cache_ttl: Duration::from_secs(30),

--- a/src/call/app/app_context.rs
+++ b/src/call/app/app_context.rs
@@ -159,8 +159,7 @@ impl ApplicationContext {
         Self {
             session_vars: Arc::new(DashMap::new()),
             db,
-            http_client: crate::http_util::build_keepalive_client(None, None)
-                .unwrap_or_else(|_| reqwest::Client::new()),
+            http_client: crate::http_util::shared_keepalive_client().clone(),
             call_info,
             invocation: None,
             config,

--- a/src/call/app/ivr/provider.rs
+++ b/src/call/app/ivr/provider.rs
@@ -289,8 +289,7 @@ impl StepProvider {
         Self {
             url: url.into(),
             headers: HashMap::new(),
-            http_client: crate::http_util::build_keepalive_client(None, None)
-                .unwrap_or_else(|_| reqwest::Client::new()),
+            http_client: crate::http_util::shared_keepalive_client().clone(),
             retry: RetryConfig::default(),
             prefer_ivr_fallback: false,
         }


### PR DESCRIPTION
## What

`ApplicationContext::new` (run once per INVITE / call session) built a fresh `reqwest` client. Each build forced rustls to reload + base64-parse the entire native CA certificate store (`rustls_native_certs::load_pem_certs`) — under load that is the dominant CPU cost.

## Evidence (benchmark, 50 cps)

- ~81% of CPU profile was a blocking task in `rustls_native_certs`/base64 decode, reached via:
  `SipSession::new -> ApplicationContext::new -> build_keepalive_client -> reqwest::ClientBuilder::build -> rustls_platform_verifier::Verifier::new -> load_native_certs`
- After switching to the shared singleton: CPU at steady state dropped ~478% -> ~250%; the per-call client path disappears from the profile (0.00s).

<img width="1809" height="1157" alt="image" src="https://github.com/user-attachments/assets/181392eb-ec73-4399-bba9-cfc182037acb" />


## Change

Use the already-existing `shared_keepalive_client()` (`OnceLock`-cached) instead of `build_keepalive_client` per instance in:
- `src/call/app/app_context.rs`
- `src/call/app/ivr/provider.rs`
- `src/call/app/agent_registry/http.rs`

`reqwest::Client` is an `Arc` internally, so cloning the shared one is cheap.