### PR TITLE
fix: preserve agent state across registration lifecycle changes

### DIFF
--- a/src/proxy/locator.rs
+++ b/src/proxy/locator.rs
@@ -79,6 +79,7 @@ pub trait Locator: Send + Sync {
     fn set_realm_checker(&self, _checker: RealmChecker) {}
     async fn register(&self, username: &str, realm: Option<&str>, location: Location)
     -> Result<()>;
+    async fn has_active_bindings(&self, username: &str, realm: Option<&str>) -> Result<bool>;
     async fn unregister(&self, username: &str, realm: Option<&str>) -> Result<()>;
     async fn unregister_with_address(&self, addr: &SipAddr) -> Result<Option<Vec<Location>>>;
     async fn lookup(&self, uri: &rsipstack::sip::Uri) -> Result<Vec<Location>>;
@@ -643,6 +644,18 @@ impl Locator for MemoryLocator {
         self.locations.remove(&identifier);
         info!(%identifier, "unregistered all locations");
         Ok(())
+    }
+
+    async fn has_active_bindings(&self, username: &str, realm: Option<&str>) -> Result<bool> {
+        let identifier = self.get_identifier(username, realm).await;
+        if identifier.is_empty() {
+            return Ok(false);
+        }
+        let now = Instant::now();
+        Ok(self
+            .locations
+            .get(&identifier)
+            .is_some_and(|map| map.values().any(|location| !location.is_expired_at(now))))
     }
 
     async fn unregister_with_address(&self, addr: &SipAddr) -> Result<Option<Vec<Location>>> {

--- a/src/proxy/locator_db.rs
+++ b/src/proxy/locator_db.rs
@@ -226,6 +226,29 @@ impl DbLocator {
             .map_err(|e| anyhow::anyhow!("Migration error (add instance_id): {}", e))?;
         Ok(())
     }
+
+    async fn normalize_identity(
+        &self,
+        username: &str,
+        realm: Option<&str>,
+    ) -> Option<(String, String)> {
+        let username = username.trim().to_ascii_lowercase();
+        if username.is_empty() {
+            return None;
+        }
+        let realm = match realm {
+            Some(realm) if !realm.trim().is_empty() => {
+                let realm = realm.trim();
+                if self.is_local_realm(realm).await {
+                    "localhost".to_string()
+                } else {
+                    realm.to_ascii_lowercase()
+                }
+            }
+            _ => String::new(),
+        };
+        Some((username, realm))
+    }
 }
 
 fn parse_transport_token(value: &str) -> Option<rsipstack::sip::transport::Transport> {
@@ -360,21 +383,8 @@ impl Locator for DbLocator {
         // Default implementation for standard cases:
         let aor = location.aor.to_string();
         let expires = location.expires as i64;
-        let username_key = username.trim().to_ascii_lowercase();
-        if username_key.is_empty() {
+        let Some((username_key, realm_key)) = self.normalize_identity(username, realm).await else {
             return Err(anyhow::anyhow!("Cannot register location without username"));
-        }
-
-        let realm_key = match realm {
-            Some(r) if !r.trim().is_empty() => {
-                let r = r.trim();
-                if self.is_local_realm(r).await {
-                    "localhost".to_string()
-                } else {
-                    r.to_ascii_lowercase()
-                }
-            }
-            _ => String::new(),
         };
         let destination = match &location.destination {
             Some(dest) => dest,
@@ -589,21 +599,8 @@ impl Locator for DbLocator {
 
     async fn unregister(&self, username: &str, realm: Option<&str>) -> Result<()> {
         // Standard implementation for other cases
-        let username_key = username.trim().to_ascii_lowercase();
-        if username_key.is_empty() {
+        let Some((username_key, realm_key)) = self.normalize_identity(username, realm).await else {
             return Ok(());
-        }
-
-        let realm_key = match realm {
-            Some(r) if !r.trim().is_empty() => {
-                let r = r.trim();
-                if self.is_local_realm(r).await {
-                    "localhost".to_string()
-                } else {
-                    r.to_ascii_lowercase()
-                }
-            }
-            _ => String::new(),
         };
 
         Entity::delete_many()
@@ -614,6 +611,22 @@ impl Locator for DbLocator {
             .map_err(|e| anyhow::anyhow!("Database error on unregister: {}", e))?;
 
         Ok(())
+    }
+
+    async fn has_active_bindings(&self, username: &str, realm: Option<&str>) -> Result<bool> {
+        let Some((username, realm)) = self.normalize_identity(username, realm).await else {
+            return Ok(false);
+        };
+        let locations = Entity::find()
+            .filter(Column::Username.eq(username))
+            .filter(Column::Realm.eq(realm))
+            .all(&self.db)
+            .await
+            .map_err(|e| anyhow::anyhow!("Database error on active binding lookup: {}", e))?;
+        let now = now_epoch_secs();
+        Ok(locations
+            .into_iter()
+            .any(|location| !is_location_expired(location.expires, location.last_modified, now)))
     }
 
     async fn lookup(&self, uri: &rsipstack::sip::Uri) -> Result<Vec<Location>> {

--- a/src/proxy/registrar.rs
+++ b/src/proxy/registrar.rs
@@ -11,7 +11,7 @@ use rsipstack::sip::{Header, Param, Transport, Uri};
 use rsipstack::{transaction::transaction::Transaction, transport::SipAddr};
 use std::{collections::HashMap, sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 #[derive(Clone)]
 pub struct RegistrarModule {
@@ -654,9 +654,30 @@ impl ProxyModule for RegistrarModule {
                     metrics::sip::registration_succeeded(&realm);
                     if let Some(locator_events) = &self.server.locator_events {
                         if location.expires == 0 {
-                            locator_events
-                                .send(LocatorEvent::Unregistered(location))
-                                .ok();
+                            match self
+                                .server
+                                .locator
+                                .has_active_bindings(
+                                    user.username.as_str(),
+                                    user.realm.as_deref(),
+                                )
+                                .await
+                            {
+                                Ok(true) => debug!(
+                                    username = %user.username,
+                                    "Binding removed while user remains registered"
+                                ),
+                                Ok(false) => {
+                                    locator_events
+                                        .send(LocatorEvent::Unregistered(location))
+                                        .ok();
+                                }
+                                Err(error) => warn!(
+                                    username = %user.username,
+                                    error = %error,
+                                    "Failed to verify remaining bindings after unregister"
+                                ),
+                            }
                         } else {
                             locator_events.send(LocatorEvent::Registered(location)).ok();
                         }

--- a/src/proxy/tests/locator_db_test.rs
+++ b/src/proxy/tests/locator_db_test.rs
@@ -53,6 +53,12 @@ async fn test_db_locator() {
     assert_eq!(locations.len(), 1);
     assert_eq!(locations[0].aor.to_string(), aor.to_string());
     assert_eq!(locations[0].expires, 3600);
+    assert!(
+        locator
+            .has_active_bindings("alice", Some("rustpbx.com"))
+            .await
+            .unwrap()
+    );
 
     // Match the relevant components of the SipAddr
     match &locations[0].destination {
@@ -74,6 +80,12 @@ async fn test_db_locator() {
         .unregister("alice", Some("rustpbx.com"))
         .await
         .unwrap();
+    assert!(
+        !locator
+            .has_active_bindings("alice", Some("rustpbx.com"))
+            .await
+            .unwrap()
+    );
 
     // Lookup should now return none (empty) or an error, both acceptable
     let result = locator

--- a/src/proxy/tests/test_registrar.rs
+++ b/src/proxy/tests/test_registrar.rs
@@ -2,7 +2,7 @@ use super::common::{
     create_register_request, create_test_request, create_test_server,
     create_test_server_with_config, create_transaction,
 };
-use crate::call::TransactionCookie;
+use crate::call::{Location, TransactionCookie};
 use crate::config::ProxyConfig;
 use crate::proxy::registrar::RegistrarModule;
 use crate::proxy::{ProxyAction, ProxyModule};
@@ -112,6 +112,66 @@ async fn test_registrar_unregister() {
     if let Ok(v) = locations {
         assert!(v.is_empty(), "Expected no locations after unregister")
     }
+}
+
+#[tokio::test]
+async fn test_registrar_unregister_keeps_user_online_with_another_binding() {
+    let config = ProxyConfig {
+        realms: Some(vec!["example.com".to_string()]),
+        ..Default::default()
+    };
+    let (server_inner, config) = create_test_server_with_config(config).await;
+    let module = RegistrarModule::new(server_inner.clone(), config);
+
+    let register_request = create_register_request("agent-a", "example.com", Some(60));
+    let registered_aor = register_request.uri.clone();
+    let registered_realm = registered_aor.host_with_port.to_string();
+    let (mut tx, _) = create_transaction(register_request).await;
+    module
+        .on_transaction_begin(
+            CancellationToken::new(),
+            &mut tx,
+            TransactionCookie::default(),
+        )
+        .await
+        .unwrap();
+
+    let second_aor = create_register_request("new-device", "client.invalid", None).uri;
+    server_inner
+        .locator
+        .register(
+            "agent-a",
+            Some(&registered_realm),
+            Location {
+                aor: second_aor.clone(),
+                expires: 60,
+                registered_aor: Some(registered_aor.clone()),
+                instance_id: Some("new-binding".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut events = server_inner.locator_events.as_ref().unwrap().subscribe();
+    let unregister_request = create_register_request("agent-a", "example.com", Some(0));
+    let (mut tx, _) = create_transaction(unregister_request).await;
+    module
+        .on_transaction_begin(
+            CancellationToken::new(),
+            &mut tx,
+            TransactionCookie::default(),
+        )
+        .await
+        .unwrap();
+
+    let locations = server_inner.locator.lookup(&registered_aor).await.unwrap();
+    assert_eq!(locations.len(), 1);
+    assert_eq!(locations[0].aor, second_aor);
+    assert!(matches!(
+        events.try_recv(),
+        Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
A SIP identity may have multiple active bindings at the same time. When one
device unregisters, the registrar currently emits a full unregistration event
even if another valid binding remains. The CC registrar bridge then marks the
agent offline although the agent is still registered and reachable through
another device.

The agent creation path has a related runtime consistency issue. After the new
agent row is inserted, the handler calls the regular registry registration
path. For a database-backed registry, that path attempts to persist the same
agent again. The duplicate insert fails, and the ignored result can leave the
new agent absent from runtime state until a later reload.

This change addresses both lifecycle gaps:

- Add an active-binding query to the locator interface, with implementations
  for both the in-memory and database-backed locators.
- Reuse the same normalized username and realm identity for registration,
  unregistration, and active-binding lookup.
- Treat expired locations as inactive when determining whether the user still
  has a valid registration.
- Emit the full unregistration event only after the final active binding has
  been removed.
- Preserve the current registered state when the remaining-binding lookup
  fails, avoiding a false offline transition caused by uncertain storage
  state.
- Load a newly created agent directly from the model returned by the successful
  database insert.
- Avoid calling the normal registration path after persistence, preventing a
  duplicate database insert while making the new agent immediately available
  to runtime-backed operations.
- Extend the CC addon submodule reference to include the runtime loading
  behavior.

The final-binding behavior remains unchanged: removing the last valid binding
still emits the unregistration event and allows the CC bridge to move the
agent offline. Normal registration events and existing database schemas are
also unchanged.

Regression coverage verifies that:

- removing one of multiple bindings does not emit a full unregistration event;
- the remaining binding stays available after the other device unregisters;
- active-binding lookup reflects registration and unregistration state for
  the database-backed locator; and
- a newly created agent is immediately available to runtime-backed endpoints
  without requiring a reload or a second database write.
