### PR TITLE
fix(media): call leg handling causing memory leak under load

### DIFF
--- a/crates/rustpbx-media/src/leg.rs
+++ b/crates/rustpbx-media/src/leg.rs
@@ -353,9 +353,14 @@ impl LegInner {
 
         let was_relay = Arc::new(AtomicBool::new(false));
         // Keep paced-sender RTCP SR / next-seq coherent while rewrite owns the
-        // shared WebRTC outbound SSRC.
+        // shared WebRTC outbound SSRC. Hold the audio sender as a WEAK ref so
+        // this observer cannot keep the PeerConnection or RtpTransport alive in
+        // a cycle: the observer is attached to the transport, and a strong
+        // sender would hold that same transport (transport -> observer ->
+        // sender -> transport), which reference counting never frees.
+        let audio_sender = audio_rtp_sender(&pc).map(|s| Arc::downgrade(&s));
         pc.add_observer(Arc::new(OutboundClockSync {
-            pc: pc.clone(),
+            sender: audio_sender,
             relay_active: was_relay.clone(),
         }));
 
@@ -985,7 +990,7 @@ fn seed_rewrite_options_from_destination(
 /// While rewrite owns the shared playback SSRC, feed each outbound packet into
 /// the paced sender so RTCP SR and the next IVR sequence stay coherent.
 struct OutboundClockSync {
-    pc: PeerConnection,
+    sender: Option<std::sync::Weak<rustrtc::peer_connection::RtpSender>>,
     relay_active: Arc<AtomicBool>,
 }
 
@@ -994,7 +999,7 @@ impl rustrtc::peer_connection::RtpObserver for OutboundClockSync {
         if !self.relay_active.load(Ordering::SeqCst) {
             return;
         }
-        let Some(sender) = audio_rtp_sender(&self.pc) else {
+        let Some(sender) = self.sender.as_ref().and_then(|w| w.upgrade()) else {
             return;
         };
         if packet.header.ssrc != sender.ssrc() {


### PR DESCRIPTION
## Problem

Under sustained load (50 cps), `rustpbx` memory grows without bound — roughly
400–780 MB/min, reaching the 8 GiB container limit in ~10 minutes. About
**70 KB per call** is allocated and never freed.

Before fix
<img width="1841" height="349" alt="99d66539620c6e0d1a0ffd1ed88bef93" src="https://github.com/user-attachments/assets/5a2fa538-2ab2-4460-8b48-79ad8de178ea" />

After fix
<img width="1833" height="345" alt="afd1dcd70d26993f034b1abe42da7f67" src="https://github.com/user-attachments/assets/83a7556e-f694-488e-b4a7-c839778f883d" />


## Root cause

<img width="1675" height="949" alt="image" src="https://github.com/user-attachments/assets/422c9807-81b4-46b8-b8b1-2571be78fee3" />


Memory Profiling point to session building process strongly. With step by step metrics collection and analyzing, root cause is identified

Commit `5f4a3106` ("fix(media): stop WebRTC Opus IVR pops and harden egress
timeline", 2026-08-21, jinti) added the `OutboundClockSync` RTP observer and
registered it on the `PeerConnection` with a **strong `pc` reference**:

```
pc.rtp_observers → OutboundClockSync → pc      (cycle #1)
```

That alone keeps the `PeerConnection` alive. Even after replacing `pc` with
the `RtpSender`, the observer is *also* attached to the RTP transport
(`attach_registered_observers`), and the sender holds that same transport:

```
transport.observers → OutboundClockSync → sender → sender.transport = transport   (cycle #2)
```

Rust reference counting never collects either cycle, so the `RtpTransport`
and its `IngressTap` observer (also registered on the transport) are retained
forever.

## Fix

Hold a `Weak<RtpSender>` in `OutboundClockSync` instead of a strong
`PeerConnection`/`RtpSender`, upgrading on use in `on_egress`. A `Weak` does
not keep the sender alive, so once the `PeerConnectionInner` drops, the sender
drops, the transport's last strong ref goes, and the transport + tap free.

## Verification

- Instrumented `RtpTransport`/`IngressTap` lifecycle counters: before the fix
  **3600 created / 0 dropped**; after, **3600 / 3600**.
- `jemalloc` `stats.allocated` stays flat across repeated 1,800-call runs
  (~62 MB) instead of growing ~70 KB/call.
- 50 cps × 10 min with recording + CDR + RWI enabled: memory plateaus at
  ~470 MiB (was unbounded).
