### PR TITLE
fix(test): pass http_client to ApplicationContext::new in queue test

### DIFF
--- a/src/call/app/queue_test.rs
+++ b/src/call/app/queue_test.rs
@@ -2810,6 +2810,7 @@ mod tests {
                     route_name: None,
                 },
                 Arc::new(crate::config::Config::default()),
+                reqwest::Client::new(),
             );
             ctx.rwi_gateway = Some(gw);
 


### PR DESCRIPTION
## Problem

`cargo test --lib` does not compile on `main`: `ApplicationContext::new`
gained an `http_client` parameter, but one call site in
`src/call/app/queue_test.rs` was not updated (the other call sites were).

## Fix

Pass `reqwest::Client::new()` as the fourth argument at the stale call
site. One line, test-only.

## Verification

`cargo test --lib` now compiles (same pass/fail set as before the
signature change introduced the breakage).
