### PR TITLE
feat(proxy): add http_router caller override; invalid URI fails the call

### DIFF
--- a/docs/config/04-routing.md
+++ b/docs/config/04-routing.md
@@ -139,6 +139,7 @@ headers = { "X-Api-Key" = "secret" }
 | `rtp_timeout` | int | RTP timeout per direction in seconds — if no audio received on either direction for this duration, call is terminated. Overrides proxy-level `rtp_timeout`. Set to `0` to disable. (default: uses proxy config, 30s) |
 | `media_proxy` | string | Media proxy mode: `auto`, `all`, `none`, `nat` |
 | `headers` | object | Custom SIP headers to add to the outgoing INVITE (key-value) |
+| `caller` | string | Caller override for the callee leg (From header). Accepts a full SIP URI (`sip:88888888@pbx.example.com`), a `user@host` shorthand, or a bare user qualified with the caller's realm. Omit to keep the authenticated caller. An unparseable value fails the call with `500 Server Internal Error` |
 | `with_original_headers` | bool | Per-route override of original-header passthrough: `true` forwards the original INVITE's custom headers to the callee leg (equivalent to `header_passthrough.mode = "all"`); `false` forwards none. When omitted, the internal-vs-trunk resolution applies — internal destinations forward all custom headers, external trunks forward per their `header_passthrough` config (default: none). Core SIP headers (`Via`/`From`/`To`/`Call-ID`/`CSeq`/`Contact`/...) are never forwarded. |
 | `extensions` | object | Custom key-value pairs stored in the dialplan (useful for CDRs) |
 

--- a/src/proxy/routing/http.rs
+++ b/src/proxy/routing/http.rs
@@ -1,7 +1,7 @@
 use crate::call::cookie::SpamResult;
 use crate::call::{
     DialDirection, DialStrategy, Dialplan, Location, RouteInvite, SipUser, TransactionCookie,
-    TrunkContext,
+    TrunkContext, build_sip_uri,
 };
 use crate::config::{
     HttpRouterConfig, MediaProxyMode, RecordingAutoStartAt, RecordingPolicy, RtpConfig,
@@ -117,6 +117,12 @@ struct HttpResponsePayload {
     /// Allowed audio codecs. If set, restricts the audio codecs used for this call.
     /// Values are codec names like "pcma", "pcmu", "g722", "opus", "g729".
     pub allow_codecs: Option<Vec<String>>,
+    /// Caller override for the callee leg (From header). Accepts a full SIP
+    /// URI ("sip:88888888@pbx.example.com"), a "user@host" shorthand, or a
+    /// bare user which is qualified with the caller's realm. When omitted the
+    /// authenticated caller is kept. An unparseable value fails the call
+    /// immediately with 500 Server Internal Error.
+    pub caller: Option<String>,
 }
 
 #[async_trait]
@@ -304,6 +310,35 @@ impl CallRouter for HttpCallRouter {
 
                 if let Some(from) = caller.from.as_ref() {
                     dialplan = dialplan.with_caller(from.clone());
+                }
+
+                if let Some(caller_override) = result
+                    .caller
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                {
+                    let realm = caller.realm.clone().unwrap_or_else(|| {
+                        caller
+                            .from
+                            .as_ref()
+                            .map(|from| from.host().to_string())
+                            .unwrap_or_default()
+                    });
+                    match rsipstack::sip::Uri::try_from(build_sip_uri(caller_override, &realm)) {
+                        Ok(uri) => dialplan = dialplan.with_caller(uri),
+                        Err(e) => {
+                            return Err(RouteError {
+                                error: anyhow!(
+                                    "HTTP router returned invalid caller override {:?}: {}",
+                                    caller_override,
+                                    e
+                                ),
+                                status: Some(rsipstack::sip::StatusCode::ServerInternalError),
+                                extensions: None,
+                            });
+                        }
+                    }
                 }
 
                 dialplan = dialplan.with_targets(strategy);

--- a/tests/proxy_routing/http_tests.rs
+++ b/tests/proxy_routing/http_tests.rs
@@ -1192,4 +1192,57 @@ mod tests {
             "with_original_headers=false must map to no passthrough"
         );
     }
+
+    #[tokio::test]
+    async fn test_http_router_forward_caller_rewrite_full_uri() {
+        let dialplan = resolve_with_response(json!({
+            "action": "forward",
+            "targets": ["sip:1001@127.0.0.1"],
+            "caller": "sip:88888888@pbx.example.com"
+        }))
+        .await
+        .unwrap();
+
+        let caller = dialplan.caller.expect("dialplan caller must be set");
+        assert_eq!(caller.to_string(), "sip:88888888@pbx.example.com");
+    }
+
+    #[tokio::test]
+    async fn test_http_router_forward_caller_rewrite_bare_user() {
+        let dialplan = resolve_with_response(json!({
+            "action": "forward",
+            "targets": ["sip:1001@127.0.0.1"],
+            "caller": "88888888"
+        }))
+        .await
+        .unwrap();
+
+        let caller = dialplan.caller.expect("dialplan caller must be set");
+        assert_eq!(
+            caller.to_string(),
+            "sip:88888888@example.com",
+            "bare user must be qualified with the caller's realm"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_http_router_forward_caller_rewrite_invalid_fails_call() {
+        let result = resolve_with_response(json!({
+            "action": "forward",
+            "targets": ["sip:1001@127.0.0.1"],
+            "caller": "sip:88888888@pbx.example.com:99999"
+        }))
+        .await;
+
+        let err = result.expect_err("an invalid caller override must fail the call");
+        assert!(
+            err.error.to_string().contains("88888888"),
+            "error should mention the invalid caller override: {}",
+            err.error
+        );
+        assert!(
+            err.status.is_some(),
+            "an invalid caller override must carry a SIP error status"
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds a route-level **caller override** to the HTTP dynamic router (`http_router`) `forward` decision: a new optional `caller` field in the response payload rewrites the From URI of the callee leg.

Accepted forms:

| value | resulting From URI |
|---|---|
| `sip:88888888@pbx.example.com` | used as-is |
| `88888888@pbx.example.com` | `sip:88888888@pbx.example.com` |
| `88888888` | `sip:88888888@<caller realm>` |

- Omitted / empty → authenticated caller is kept (unchanged behavior).
- **Unparseable value → the call fails immediately with `500 Server Internal Error`** (fail-fast via `RouteError`); the routing decision is treated as invalid rather than silently falling back to the original caller.

## Why

Static route rules can already rewrite `from.user`/`from.host` via `RewriteRules`, but the HTTP router had no equivalent — the callee-leg From was always the authenticated caller. This is a common need for trunk/wholesale routing scenarios where the routing service decides the presented caller ID per call.

The fail-fast choice matters: a malformed override coming from the router is a router bug, and silently keeping the original caller would route the call with an unexpected (and possibly non-billable) identity.

## Tests

- `test_http_router_forward_caller_rewrite_full_uri` — full URI is used verbatim
- `test_http_router_forward_caller_rewrite_bare_user` — bare user qualified with the caller's realm
- `test_http_router_forward_caller_rewrite_invalid_fails_call` — unparseable URI → `RouteError` with a SIP error status

All `proxy_routing` tests pass (82/82).

## Docs

`docs/config/04-routing.md` response-field table updated with the new `caller` field and its failure semantics.

## Validation

Verified end-to-end in a Docker benchmark (rustpbx → asterisk at 50 cps):

- valid override `88888888`: 3000/3000 INVITEs arriving at asterisk carried `From: <sip:88888888@...>` (0 with the original caller identity)
- invalid override (`...:99999`, port overflow): 1500/1500 calls rejected immediately with 500, zero INVITEs left rustpbx