### PR TITLE
fix(http_proxy): preserve upstream redirects for SSO flows

### DIFF
--- a/crates/rustpbx-http-util/src/lib.rs
+++ b/crates/rustpbx-http-util/src/lib.rs
@@ -12,6 +12,24 @@ pub fn build_keepalive_client(
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
 ) -> Result<reqwest::Client> {
+    build_client(keepalive_client_builder(timeout, connect_timeout))
+}
+
+/// Builds a keepalive client that returns redirects to its caller unchanged.
+pub fn build_keepalive_client_without_redirect(
+    timeout: Option<Duration>,
+    connect_timeout: Option<Duration>,
+) -> Result<reqwest::Client> {
+    build_client(
+        keepalive_client_builder(timeout, connect_timeout)
+            .redirect(reqwest::redirect::Policy::none()),
+    )
+}
+
+fn keepalive_client_builder(
+    timeout: Option<Duration>,
+    connect_timeout: Option<Duration>,
+) -> reqwest::ClientBuilder {
     let mut builder = reqwest::Client::builder()
         .tcp_keepalive(DEFAULT_HTTP_TCP_KEEPALIVE)
         .pool_idle_timeout(DEFAULT_HTTP_POOL_IDLE_TIMEOUT)
@@ -25,6 +43,10 @@ pub fn build_keepalive_client(
         builder = builder.connect_timeout(connect_timeout);
     }
 
+    builder
+}
+
+fn build_client(builder: reqwest::ClientBuilder) -> Result<reqwest::Client> {
     builder
         .build()
         .map_err(|e| anyhow!("Failed to build HTTP client: {}", e))


### PR DESCRIPTION
## Problem

The HTTP proxy client followed upstream redirects automatically. As a result, callers could not receive
the original `3xx` response and `Location` header required to complete SSO handoff flows.

Regular HTTP redirects were followed by the proxy itself, while redirects using a custom URI scheme
could fail before reaching the client.

## Fix

- Add a keepalive HTTP client variant that disables automatic redirect handling while preserving the
existing timeout, connection pool, and TCP keepalive behavior.
- Use the no-redirect client in the HTTP proxy, including its fallback construction path.
- Return upstream redirect responses and `Location` headers unchanged so the calling client can handle
the SSO redirect.
- Add regression coverage for both regular HTTP redirects and custom URI scheme redirects, including
verification that the proxy does not request the redirect destination.
